### PR TITLE
Plugins for add defaultValue features to google closure jsdoc.

### DIFF
--- a/plugins/gjstype.js
+++ b/plugins/gjstype.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var _ = require('underscore');
+
+exports.handlers = {
+
+    /**
+     * replace google closure type annotation style (optional, defaultValue) to jsdoc3 annotation.
+     * "{boolean=} round [false] blah blah..." to "{boolean} [round=false]"
+     */
+    beforeParse: function(e) {
+        var source = e.source,
+            gjsStyleOptionalRegex = /\{(\(?[\w]+\)?)\=\}[\t\s]+(\w+)[\t\s]+\[([\w\s\'\"]+)\]/g,
+            match,
+
+            annotation,
+            type,
+            name,
+            defaultValue,
+
+            annotationLength,
+            index,
+
+            leftPart, rightPart;
+
+        while((match = gjsStyleOptionalRegex.exec(source)) !== null){
+            annotation = match[0];
+            type = match[1];
+            name = match[2];
+            defaultValue = match[3];
+
+            annotationLength = annotation.length;
+            index = match.index;
+
+            leftPart = source.substr(0, index);
+            rightPart = source.substr(index + annotationLength, source.length - (index + annotationLength));
+
+            e.source = source = leftPart + '{' + type + '}' + ' [' + name + '=' + defaultValue + ']' + rightPart;
+        }
+
+    }
+};

--- a/plugins/test/fixtures/gjstype.js
+++ b/plugins/test/fixtures/gjstype.js
@@ -1,0 +1,8 @@
+/**
+ * @param {string=} name ['john doe'] please set name.
+ * @param {number=} age [50]
+ */
+function myFunc(name, age) {
+    name = name || 'john doe';
+    age = age || 50;
+}

--- a/plugins/test/specs/gjstype.js
+++ b/plugins/test/specs/gjstype.js
@@ -1,0 +1,18 @@
+describe('gjstype plugins', function() {
+    var parser = jasmine.createParser();
+    var path = require('jsdoc/path');
+
+    var pluginPath = 'plugins/gjstype';
+    var pluginPathResolved = path.join(env.dirname, pluginPath);
+
+    require('jsdoc/plugins').installPlugins([pluginPathResolved], parser);
+    var docSet = jasmine.getDocSetFromFile('plugins/test/fixtures/gjstype.js', parser);
+
+    it('replace default annotation of parameter description field.', function() {
+        var findRegex = /\[[\w]+\=[\w\s\'\"]+\]/g;
+        var myFunc = docSet.getByLongname('myFunc');
+
+        expect(myFunc[0].comment.match(findRegex).length).toEqual(2);
+    });
+
+});


### PR DESCRIPTION
i want to use gjslint + jsdoc3.

but gjslint's jsdoc variable type annotations are different with jsdoc3.

especially i want to use "default Value" annotation my project. that's why i make this plugin.

my plugin change below annotations.

```javascript

/**
 * @param {boolean=} useAnother [false] this make blah blah....
 */
function myFunc(useAnother) {
    useAnother = useAnother || false;
}

// replace to

/**
 * @param {boolean} [useAnother=false] this make blah blah....
 */
function myFunc(useAnother) {
    useAnother = useAnother || false;
}
```

finally i make new branch and pull this request.