### PR TITLE
Add support for ES6 classes

### DIFF
--- a/lib/jsdoc/doclet.js
+++ b/lib/jsdoc/doclet.js
@@ -57,6 +57,9 @@ function codeToKind(code) {
     else if (code.type === Syntax.ClassDeclaration) {
         kind = 'class';
     }
+    else if (code.type === Syntax.MethodDefinition && code.node.kind === '') {
+        kind = 'function';
+    }
     else if (code.node && code.node.parent) {
         parent = code.node.parent;
         if ( isFunction(parent) ) {

--- a/lib/jsdoc/doclet.js
+++ b/lib/jsdoc/doclet.js
@@ -54,6 +54,9 @@ function codeToKind(code) {
     if (code.type === Syntax.FunctionDeclaration || code.type === Syntax.FunctionExpression) {
         kind = 'function';
     }
+    else if (code.type === Syntax.ClassDeclaration) {
+        kind = 'class';
+    }
     else if (code.node && code.node.parent) {
         parent = code.node.parent;
         if ( isFunction(parent) ) {

--- a/lib/jsdoc/src/astbuilder.js
+++ b/lib/jsdoc/src/astbuilder.js
@@ -18,6 +18,7 @@ var acceptsLeadingComments = (function() {
         Syntax.FunctionDeclaration,
         Syntax.FunctionExpression,
         Syntax.MemberExpression,
+        Syntax.MethodDefinition,
         Syntax.Property,
         Syntax.TryStatement,
         Syntax.VariableDeclaration,

--- a/lib/jsdoc/src/astbuilder.js
+++ b/lib/jsdoc/src/astbuilder.js
@@ -14,6 +14,7 @@ var acceptsLeadingComments = (function() {
     var commentable = [
         Syntax.AssignmentExpression,
         Syntax.CallExpression,
+        Syntax.ClassDeclaration,
         Syntax.FunctionDeclaration,
         Syntax.FunctionExpression,
         Syntax.MemberExpression,

--- a/lib/jsdoc/src/astnode.js
+++ b/lib/jsdoc/src/astnode.js
@@ -274,6 +274,21 @@ var getInfo = exports.getInfo = function(node) {
             info.paramnames = getParamNames(node.right);
             break;
 
+        case Syntax.ClassDeclaration:
+            info.node = node;
+            info.name = nodeToString(node.id);
+            info.type = info.node.type;
+            info.paramnames = [];
+
+            node.body.body.some(function(definition) {
+              if (definition.kind === "" && definition.key.name === 'constructor') {
+                info.paramnames = getParamNames(definition.value);
+                return true;
+              }
+            });
+
+            break;
+
         // like: "function foo() {}"
         case Syntax.FunctionDeclaration:
             info.node = node;

--- a/lib/jsdoc/src/astnode.js
+++ b/lib/jsdoc/src/astnode.js
@@ -185,6 +185,13 @@ var nodeToString = exports.nodeToString = function(node) {
             }
             break;
 
+        case Syntax.MethodDefinition:
+            // e.g. "Test.prototype.run" for "class Test { run() {} }"
+            str = nodeToString(node.parent.parent.id);
+            str += node.static? '.' : '.prototype.';
+            str += nodeToString(node.key);
+            break;
+
         case Syntax.ObjectExpression:
             tempObject = {};
             node.properties.forEach(function(prop) {
@@ -281,7 +288,7 @@ var getInfo = exports.getInfo = function(node) {
             info.paramnames = [];
 
             node.body.body.some(function(definition) {
-              if (definition.kind === "" && definition.key.name === 'constructor') {
+              if (definition.kind === '' && definition.key.name === 'constructor') {
                 info.paramnames = getParamNames(definition.value);
                 return true;
               }
@@ -318,6 +325,14 @@ var getInfo = exports.getInfo = function(node) {
             info.node = node;
             info.name = nodeToString(info.node);
             info.type = info.node.type;
+            break;
+
+        // like: "foo() {}"
+        case Syntax.MethodDefinition:
+            info.node = node;
+            info.name = nodeToString(info.node);
+            info.type = info.node.type;
+            info.paramnames = getParamNames(node.value);
             break;
 
         // like "a: 0" in "var foo = {a: 0}"

--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -382,6 +382,11 @@ Visitor.prototype.makeSymbolFoundEvent = function(node, parser, filename) {
 
             break;
 
+        case Syntax.MethodDefinition:
+            e = new SymbolFound(node, filename, extras);
+
+            break;
+
         // like the object literal in: function Foo = Class.create(/** @lends Foo */ {});
         case Syntax.ObjectExpression:
             e = new SymbolFound(node, filename, extras);
@@ -411,14 +416,12 @@ Visitor.prototype.makeSymbolFoundEvent = function(node, parser, filename) {
 
         // for now, log a warning for all ES6 nodes, since we don't do anything useful with them
         case Syntax.ArrowFunctionExpression:
-        case Syntax.ClassBody:
         case Syntax.ClassExpression:
         case Syntax.ExportBatchSpecifier:
         case Syntax.ExportDeclaration:
         case Syntax.ExportSpecifier:
         case Syntax.ImportDeclaration:
         case Syntax.ImportSpecifier:
-        case Syntax.MethodDefinition:
         case Syntax.ModuleDeclaration:
         case Syntax.SpreadElement:
         case Syntax.TaggedTemplateExpression:

--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -335,6 +335,16 @@ Visitor.prototype.makeSymbolFoundEvent = function(node, parser, filename) {
 
             break;
 
+        // like: class foo {}
+        case Syntax.ClassDeclaration:
+            e = new SymbolFound(node, filename, extras);
+
+            trackVars(parser, node, e);
+
+            basename = parser.getBasename(e.code.name);
+
+            break;
+
         // like: function foo() {}
         case Syntax.FunctionDeclaration:
             // falls through
@@ -402,7 +412,6 @@ Visitor.prototype.makeSymbolFoundEvent = function(node, parser, filename) {
         // for now, log a warning for all ES6 nodes, since we don't do anything useful with them
         case Syntax.ArrowFunctionExpression:
         case Syntax.ClassBody:
-        case Syntax.ClassDeclaration:
         case Syntax.ClassExpression:
         case Syntax.ExportBatchSpecifier:
         case Syntax.ExportDeclaration:

--- a/test/fixtures/classtag.js
+++ b/test/fixtures/classtag.js
@@ -7,6 +7,12 @@ var Ticker = function() {
 };
 
 /**
+    Describe the Subscription class here.
+ */
+class Subscription {
+}
+
+/**
     Describe the NewsSource class here.
     @class NewsSource
  */

--- a/test/fixtures/methoddefinition.js
+++ b/test/fixtures/methoddefinition.js
@@ -1,0 +1,9 @@
+class Test {
+    /** Document me. */
+    run() {
+    }
+
+    /** Static document me. */
+    static run() {
+    }
+}

--- a/test/specs/documentation/methoddefinition.js
+++ b/test/specs/documentation/methoddefinition.js
@@ -1,0 +1,16 @@
+/*global describe, expect, it, jasmine */
+describe('method definition inside a class declaration', function() {
+    var docSet = jasmine.getDocSetFromFile('test/fixtures/methoddefinition.js'),
+        runMethod = docSet.getByLongname('Test#run')[0],
+        staticRunMethod = docSet.getByLongname('Test.run')[0];
+
+    it('methods should have documentation comments', function() {
+        expect(runMethod).toBeDefined();
+        expect(runMethod.description).toBe('Document me.');
+        expect(runMethod.kind).toBe('function');
+
+        expect(staticRunMethod).toBeDefined();
+        expect(staticRunMethod.description).toBe('Static document me.');
+        expect(staticRunMethod.kind).toBe('function');
+    });
+});

--- a/test/specs/tags/classtag.js
+++ b/test/specs/tags/classtag.js
@@ -1,7 +1,8 @@
 describe("@class tag", function() {
     var docSet = jasmine.getDocSetFromFile('test/fixtures/classtag.js'),
         ticker = docSet.getByLongname('Ticker')[0],
-        news = docSet.getByLongname('NewsSource')[0];
+        news = docSet.getByLongname('NewsSource')[0],
+        subscription = docSet.getByLongname('Subscription')[0];
 
     it('When a symbol has a @class tag, the doclet has a kind property set to "class".', function() {
         expect(ticker.kind).toBe('class');
@@ -10,5 +11,11 @@ describe("@class tag", function() {
     it('When a symbol has a @class tag with a value, the doclet has a name property set to that value.', function() {
         expect(news.kind).toBe('class');
         expect(news.longname).toBe('NewsSource');
+    });
+
+    it('When a symbol is a class declaration, the doclet does not require the @class tag', function() {
+        expect(subscription.kind).toBe('class');
+        expect(subscription.longname).toBe('Subscription');
+        expect(subscription.description).toBe('Describe the Subscription class here.');
     });
 });


### PR DESCRIPTION
This is not entirely complete yet, but is close. The one known issue is that, since the AST nodes for the `ClassDeclaration` and the constructor `MethodDefinition` are distinct, I don't know how to make jsdoc join the documentation for them together to make it show as you'd expect (that is, params to the `constructor(arg1, arg2)` method should show under the docs for the class itself e.g. `new Foo(arg1, arg2)`). Here is an example of what I'm talking about:

```js
/**
 * A point in a 2-dimensional coordinate system.
 */
class Point {
  /**
   * @param {number} x
   * @param {number} y
   */
  constructor(x, y) {
    this.x = x;
    this.y = y;
  }
}
```

I tried fixing this by implicitly adding the `@constructs Point` tag to the constructor method, but that ended up just making it an alias and overrode the description docs on the `ClassDeclaration` node. I tried to figure out how to simply concatenate the docs or move the tags over from the `constructor` method to the class declaration, but it wasn't really clear how to do this. Any hints?