### PR TITLE
Failing test for numeric enum (#946)

### DIFF
--- a/test/fixtures/numericenum.js
+++ b/test/fixtures/numericenum.js
@@ -1,0 +1,8 @@
+/**
+ * Enum with numeric keys.
+ * @enum {string}
+ */
+var NumericEnum = {
+    0: 'Zero',
+    1: 'One'
+};

--- a/test/specs/tags/enumtag.js
+++ b/test/specs/tags/enumtag.js
@@ -31,6 +31,13 @@ describe('@enum tag', function() {
         expect( dump(tristate) ).not.toMatch('<CircularRef>');
     });
 
+    it('Should support numeric keys', function() {
+        var docSet = jasmine.getDocSetFromFile('test/fixtures/numericenum.js');
+        var numericEnum = docSet.getByLongname('NumericEnum')[0];
+        expect(numericEnum.properties[0].name).toBe('0');
+        expect(numericEnum.properties[1].name).toBe('1');
+    });
+
     describe('chained assignments', function() {
         var pentaState;
         var PENTASTATE;


### PR DESCRIPTION
Here is a failing test for #946. You should see:

```
1) Should support numeric keys
  Message:
    TypeError: Cannot read property 'type' of undefined
  Stacktrace:
    TypeError: Cannot read property 'type' of undefined
    at jsdoc/lib/jsdoc/src/parser.js:525:41
    at Array.forEach (native)
    at Parser.resolveEnum (jsdoc/lib/jsdoc/src/parser.js:520:13)
    at Visitor.visitNode (jsdoc/lib/jsdoc/src/visitor.js:381:24)
    at Visitor.visit (jsdoc/lib/jsdoc/src/visitor.js:284:27)
    at Walker.recurse (jsdoc/lib/jsdoc/src/walker.js:530:44)
    at Parser._walkAst (jsdoc/lib/jsdoc/src/parser.js:246:18)
    at Parser._parseSourceCode (jsdoc/lib/jsdoc/src/parser.js:236:18)
    at Parser.parse (jsdoc/lib/jsdoc/src/parser.js:157:18)
    at Object.jasmine.getDocSetFromFile (jsdoc/test/jasmine-jsdoc.js:159:26)
```


### Notes

The test will pass if you change the fixture to use string keys (simply quote `"0"` and `"1"`).

I would expect it to pass either way.