### PR TITLE
Failing test for numeric properties (#945)

### DIFF
--- a/test/fixtures/numericpropertytag.js
+++ b/test/fixtures/numericpropertytag.js
@@ -1,0 +1,11 @@
+/**
+ * @namespace
+ * @property {String} 1 The number one.
+ * @property {String} 2 The number two.
+ * @property {String} 3 The number three.
+ */
+var numericObject = {
+    1: 'a',
+    2: 'b',
+    3: 'c'
+};

--- a/test/specs/tags/propertytag.js
+++ b/test/specs/tags/propertytag.js
@@ -19,4 +19,16 @@ describe('@property tag', function() {
         expect(myobject.properties[1].description).toBe('The default values.');
         expect(myobject.properties[1].type.names[0]).toBe('Object');
     });
+
+    it('When a symbol has a @property tag for a numeric property, the property appears in the doclet.', function() {
+        var docSet = jasmine.getDocSetFromFile('test/fixtures/numericpropertytag.js'),
+            numericObject = docSet.getByLongname('numericObject')[0];
+
+        expect(typeof numericObject.properties).toBe('object');
+        expect(numericObject.properties.length).toBe(3);
+
+        expect(numericObject.properties[0].name).toBe('1');
+        expect(numericObject.properties[1].name).toBe('2');
+        expect(numericObject.properties[2].name).toBe('3');
+    });
 });


### PR DESCRIPTION
Here is a failing test for #945. You should see:

```
 1) When a symbol documents numeric properties, the property appears in the doclet.
  Message:
    TypeError: Object 1 has no method 'match'
  Stacktrace:
    TypeError: Object 1 has no method 'match'
    at mustPreserveWhitespace (jsdoc/lib/jsdoc/tag.js:33:65)
    at trim (jsdoc/lib/jsdoc/tag.js:43:10)
    at new exports.Tag (jsdoc/lib/jsdoc/tag.js:189:17)
    at Doclet.addTag (jsdoc/lib/jsdoc/doclet.js:202:18)
    at newSymbolDoclet (jsdoc/lib/jsdoc/src/handlers.js:264:19)
    at null.<anonymous> (jsdoc/lib/jsdoc/src/handlers.js:331:13)
    at EventEmitter.emit (events.js:98:17)
    at Visitor.visitNode (jsdoc/lib/jsdoc/src/visitor.js:374:16)
    at Visitor.visit (jsdoc/lib/jsdoc/src/visitor.js:284:27)
    at Walker.recurse (jsdoc/lib/jsdoc/src/walker.js:530:44)
```

### Notes

I attempted a simple fix by changing `lib/jsdoc/tag.js:41` inside of `trim(text, opts, meta)`:

```js
    // Ensure the passed text is a string
    // Numeric property names will come in as numbers
    text = (text || '').toString();
```

Instead of:

```js
  text = text || '';
```

Which should fix the error that happens when the test is ran, but instead I get a schema validation error that I'm not sure how to go about solving.