### PR TITLE
812 decoupled logger

### DIFF
--- a/lib/jsdoc/util/logger.js
+++ b/lib/jsdoc/util/logger.js
@@ -72,7 +72,7 @@ var LEVELS = {
      *
      * @alias module:jsdoc/util/logger.LEVELS.INFO
      */
-     INFO: 'INFO',
+    INFO: 'INFO',
     /**
      * Log the following messages:
      *

--- a/lib/jsdoc/util/logger.js
+++ b/lib/jsdoc/util/logger.js
@@ -145,9 +145,6 @@ function addPrefix(args, level) {
 var Logger = function () {
     this.handlers = {};
     this.setLevel(DEFAULT_LEVEL);
-    this.fatalLevel = LEVELS.FATAL;
-    this.errorLevel = LEVELS.ERROR;
-    this.resetErrors();
 };
 util.inherits(Logger, require('events').EventEmitter);
 
@@ -247,34 +244,9 @@ Logger.prototype.getLevel = function () {
  * @private
  */
 Logger.prototype._canBeLogged = function (level) {
-//    console.log(level, LOG_LEVELS[level], this.logLevel, LOG_LEVELS[this.logLevel]);
     return LOG_LEVELS[this.getLevel()] >= LOG_LEVELS[level];
 };
 
-/**
- * Check if the log level is considered as fatal.
- * @private
- * @param {module:jsdoc/util/logger.LEVELS} level
- * @returns {boolean}
- */
-Logger.prototype._isFatal = function (level) {
-    return LOG_LEVELS[this.fatalLevel] >= LOG_LEVELS[level];
-};
-
-/**
- * Check if the message is considered as an error.
- * If it is, it increments the number of errors.
- * @private
- * @param {module:jsdoc/util/logger.LEVELS} level
- * @returns {boolean}
- */
-Logger.prototype._isError = function (level) {
-    if  (LOG_LEVELS[this.errorLevel] >= LOG_LEVELS[level]) {
-        this.loggedErrors++;
-        return true;
-    }
-    return false;
-};
 
 /**
  * Invoke one of the logger handlers: debug, info, fatal, warn...
@@ -289,17 +261,6 @@ Logger.prototype._invoke = function (level, logArgs) {
     if (_.isFunction(handler) && this._canBeLogged(level)) {
         handler.apply(this, addPrefix(logArgs, level));
     }
-
-
-    if (this._isFatal(level)) {
-        /**
-         * Fatal event.
-         * @event module:jsdoc/util/logger#fatal
-         */
-        this.emit('fatal');
-    }
-
-    this.errors || this._isError(level);
 
     logArgs.unshift(eventName);
     this.emit.apply(this, logArgs);
@@ -357,36 +318,6 @@ Logger.prototype.setDefaultHandlers = function () {
  */
 Logger.prototype.mute = function () {
     this.setLevel(LEVELS.SILENT);
-};
-
-/**
- * Enable the pedantic mode.
- */
-Logger.prototype.enablePedanticMode = function () {
-    this.fatalLevel = LEVELS.ERROR;
-    this.errorLevel = LEVELS.WARN;
-};
-
-/**
- * Disable the pedantic mode.
- */
-Logger.prototype.disablePedanticMode = function () {
-    this.fatalLevel = LEVELS.FATAL;
-    this.errorLevel = LEVELS.ERROR;
-};
-
-/**
- * Check if errors were thrown
- */
-Logger.prototype.hasErrors = function () {
-    return !!this.loggedErrors;
-};
-
-/**
- * Check if errors were thrown
- */
-Logger.prototype.resetErrors = function () {
-    this.loggedErrors = 0;
 };
 
 var logger = module.exports = new Logger();

--- a/lib/jsdoc/util/logger.js
+++ b/lib/jsdoc/util/logger.js
@@ -35,60 +35,23 @@
  */
 'use strict';
 
-var runtime = require('jsdoc/util/runtime');
+var _ = require('underscore');
 var util = require('util');
-
-function Logger() {}
-util.inherits(Logger, require('events').EventEmitter);
-
-var logger = module.exports = new Logger();
 
 /**
  * Logging levels for the JSDoc logger. The default logging level is
- * {@link module:jsdoc/util/logger.LEVELS.ERROR}.
+ * {@link module:jsdoc/util/logger.LEVELS.WARN}.
  *
  * @alias module:jsdoc/util/logger.LEVELS
  * @enum
- * @type {number}
  */
-var LEVELS = logger.LEVELS = {
+var LEVELS = {
     /**
-     * Do not log any messages.
+     * Log all messages.
      *
-     * @alias module:jsdoc/util/logger.LEVELS.SILENT
+     * @alias module:jsdoc/util/logger.LEVELS.VERBOSE
      */
-    SILENT: 0,
-    /**
-     * Log fatal errors that prevent JSDoc from running.
-     *
-     * @alias module:jsdoc/util/logger.LEVELS.FATAL
-     */
-    FATAL: 10,
-    /**
-     * Log all errors, including errors from which JSDoc can recover.
-     *
-     * @alias module:jsdoc/util/logger.LEVELS.ERROR
-     */
-    ERROR: 20,
-    /**
-     * Log the following messages:
-     *
-     * + Warnings
-     * + Errors
-     *
-     * @alias module:jsdoc/util/logger.LEVELS.WARN
-     */
-    WARN: 30,
-    /**
-     * Log the following messages:
-     *
-     * + Informational messages
-     * + Warnings
-     * + Errors
-     *
-     * @alias module:jsdoc/util/logger.LEVELS.INFO
-     */
-    INFO: 40,
+    VERBOSE: 'VERBOSE',
     /**
      * Log the following messages:
      *
@@ -99,17 +62,64 @@ var LEVELS = logger.LEVELS = {
      *
      * @alias module:jsdoc/util/logger.LEVELS.DEBUG
      */
-    DEBUG: 50,
+    DEBUG: 'DEBUG',
     /**
-     * Log all messages.
+     * Log the following messages:
      *
-     * @alias module:jsdoc/util/logger.LEVELS.VERBOSE
+     * + Informational messages
+     * + Warnings
+     * + Errors
+     *
+     * @alias module:jsdoc/util/logger.LEVELS.INFO
      */
-    VERBOSE: 1000
+     INFO: 'INFO',
+    /**
+     * Log the following messages:
+     *
+     * + Warnings
+     * + Errors
+     *
+     * @alias module:jsdoc/util/logger.LEVELS.WARN
+     */
+    WARN: 'WARN',
+    /**
+     * Log all errors, including errors from which JSDoc can recover.
+     *
+     * @alias module:jsdoc/util/logger.LEVELS.ERROR
+     */
+    ERROR: 'ERROR',
+    /**
+     * Log fatal errors that prevent JSDoc from running.
+     *
+     * @alias module:jsdoc/util/logger.LEVELS.FATAL
+     */
+    FATAL: 'FATAL',
+    /**
+     * Do not log any messages.
+     *
+     * @alias module:jsdoc/util/logger.LEVELS.SILENT
+     */
+    SILENT: 'SILENT'
 };
 
+/**
+ * Default log level
+ * @const
+ */
 var DEFAULT_LEVEL = LEVELS.WARN;
-var logLevel = DEFAULT_LEVEL;
+
+/**
+ * Levels weight
+ */
+var LOG_LEVELS = {
+    SILENT: 0,
+    FATAL: 10,
+    ERROR: 20,
+    WARN: 30,
+    INFO: 40,
+    DEBUG: 50,
+    VERBOSE: 1000
+};
 
 var PREFIXES = {
     DEBUG: 'DEBUG: ',
@@ -119,7 +129,8 @@ var PREFIXES = {
 };
 
 // Add a prefix to a log message if necessary.
-function addPrefix(args, prefix) {
+function addPrefix(args, level) {
+    var prefix = PREFIXES[level];
     var updatedArgs;
 
     if (prefix && typeof args[0] === 'string') {
@@ -130,34 +141,29 @@ function addPrefix(args, prefix) {
     return updatedArgs || args;
 }
 
-// TODO: document events
-function wrapLogFunction(name, func) {
-    var eventName = 'logger:' + name;
-    var upperCaseName = name.toUpperCase();
-    var level = LEVELS[upperCaseName];
-    var prefix = PREFIXES[upperCaseName];
 
-    return function() {
-        var loggerArgs;
+var Logger = function () {
+    this.handlers = {};
+    this.setLevel(DEFAULT_LEVEL);
+    this.fatalLevel = LEVELS.FATAL;
+    this.errorLevel = LEVELS.ERROR;
+    this.resetErrors();
+};
+util.inherits(Logger, require('events').EventEmitter);
 
-        var args = Array.prototype.slice.call(arguments, 0);
 
-        if (logLevel >= level) {
-            loggerArgs = addPrefix(args, prefix);
-            func.apply(null, loggerArgs);
-        }
+Logger.prototype.LEVELS = LEVELS;
 
-        args.unshift(eventName);
-        logger.emit.apply(logger, args);
-    };
-}
-
-// Print a message to STDOUT without a terminating newline.
-function printToStdout() {
-    var args = Array.prototype.slice.call(arguments, 0);
-
-    process.stdout.write( util.format.apply(util, args) );
-}
+/**
+ * Log a message at log level {@link module:jsdoc/util/logger.LEVELS.VERBOSE}.
+ *
+ * @alias module:jsdoc/util/logger.verbose
+ * @param {string} message - The message to log.
+ * @param {...*=} values - The values that will replace the message's placeholders.
+ */
+Logger.prototype.verbose = function () {
+    this._invoke(LEVELS.VERBOSE, _.toArray(arguments));
+};
 
 /**
  * Log a message at log level {@link module:jsdoc/util/logger.LEVELS.DEBUG}.
@@ -166,32 +172,10 @@ function printToStdout() {
  * @param {string} message - The message to log.
  * @param {...*=} values - The values that will replace the message's placeholders.
  */
-logger.debug = wrapLogFunction('debug', console.info);
-/**
- * Print a string at log level {@link module:jsdoc/util/logger.LEVELS.DEBUG}. The string is not
- * terminated by a newline.
- *
- * @alias module:jsdoc/util/logger.printDebug
- * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
- */
-logger.printDebug = wrapLogFunction('debug', printToStdout);
-/**
- * Log a message at log level {@link module:jsdoc/util/logger.LEVELS.ERROR}.
- *
- * @alias module:jsdoc/util/logger.error
- * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
- */
-logger.error = wrapLogFunction('error', console.error);
-/**
- * Log a message at log level {@link module:jsdoc/util/logger.LEVELS.FATAL}.
- *
- * @alias module:jsdoc/util/logger.fatal
- * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
- */
-logger.fatal = wrapLogFunction('fatal', console.error);
+Logger.prototype.debug = function () {
+    this._invoke(LEVELS.DEBUG, _.toArray(arguments));
+};
+
 /**
  * Log a message at log level {@link module:jsdoc/util/logger.LEVELS.INFO}.
  *
@@ -199,33 +183,21 @@ logger.fatal = wrapLogFunction('fatal', console.error);
  * @param {string} message - The message to log.
  * @param {...*=} values - The values that will replace the message's placeholders.
  */
-logger.info = wrapLogFunction('info', console.info);
+Logger.prototype.info = function () {
+    this._invoke(LEVELS.INFO, _.toArray(arguments));
+};
+
 /**
- * Print a string at log level {@link module:jsdoc/util/logger.LEVELS.INFO}. The string is not
- * terminated by a newline.
+ * Log a message at log level {@link module:jsdoc/util/logger.LEVELS.ERROR}.
  *
- * @alias module:jsdoc/util/logger.printInfo
+ * @alias module:jsdoc/util/logger.error
  * @param {string} message - The message to log.
  * @param {...*=} values - The values that will replace the message's placeholders.
  */
-logger.printInfo = wrapLogFunction('info', printToStdout);
-/**
- * Log a message at log level {@link module:jsdoc/util/logger.LEVELS.VERBOSE}.
- *
- * @alias module:jsdoc/util/logger.verbose
- * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
- */
-logger.verbose = wrapLogFunction('verbose', console.info);
-/**
- * Print a string at log level {@link module:jsdoc/util/logger.LEVELS.VERBOSE}. The string is not
- * terminated by a newline.
- *
- * @alias module:jsdoc/util/logger.printVerbose
- * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
- */
-logger.printVerbose = wrapLogFunction('verbose', printToStdout);
+Logger.prototype.error = function () {
+    this._invoke(LEVELS.ERROR, _.toArray(arguments));
+};
+
 /**
  * Log a message at log level {@link module:jsdoc/util/logger.LEVELS.WARN}.
  *
@@ -233,16 +205,29 @@ logger.printVerbose = wrapLogFunction('verbose', printToStdout);
  * @param {string} message - The message to log.
  * @param {...*=} values - The values that will replace the message's placeholders.
  */
-logger.warn = wrapLogFunction('warn', console.warn);
+Logger.prototype.warn = function () {
+    this._invoke(LEVELS.WARN, _.toArray(arguments));
+};
+
+/**
+ * Log a message at log level {@link module:jsdoc/util/logger.LEVELS.FATAL}.
+ *
+ * @alias module:jsdoc/util/logger.fatal
+ * @param {string} message - The message to log.
+ * @param {...*=} values - The values that will replace the message's placeholders.
+ */
+Logger.prototype.fatal = function () {
+    this._invoke(LEVELS.FATAL, _.toArray(arguments));
+};
 
 /**
  * Set the log level.
  *
  * @alias module:jsdoc/util/logger.setLevel
- * @param {module:jsdoc/util/logger.LEVELS} level - The log level to use.
+ * @param {module:jsdoc/util/logger.LEVELS} logLevel - The log level to use.
  */
-logger.setLevel = function setLevel(level) {
-    logLevel = (level !== undefined) ? level : DEFAULT_LEVEL;
+Logger.prototype.setLevel = function (logLevel) {
+    this.logLevel = logLevel;
 };
 
 /**
@@ -251,6 +236,159 @@ logger.setLevel = function setLevel(level) {
  * @alias module:jsdoc/util/logger.getLevel
  * @return {module:jsdoc/util/logger.LEVELS} The current log level.
  */
-logger.getLevel = function getLevel() {
-    return logLevel;
+Logger.prototype.getLevel = function () {
+    return this.logLevel || DEFAULT_LEVEL;
 };
+
+/**
+ * Check if the log level lets us log the message.
+ * @param {module:jsdoc/util/logger.LEVELS} level
+ * @returns {boolean}
+ * @private
+ */
+Logger.prototype._canBeLogged = function (level) {
+//    console.log(level, LOG_LEVELS[level], this.logLevel, LOG_LEVELS[this.logLevel]);
+    return LOG_LEVELS[this.getLevel()] >= LOG_LEVELS[level];
+};
+
+/**
+ * Check if the log level is considered as fatal.
+ * @private
+ * @param {module:jsdoc/util/logger.LEVELS} level
+ * @returns {boolean}
+ */
+Logger.prototype._isFatal = function (level) {
+    return LOG_LEVELS[this.fatalLevel] >= LOG_LEVELS[level];
+};
+
+/**
+ * Check if the message is considered as an error.
+ * If it is, it increments the number of errors.
+ * @private
+ * @param {module:jsdoc/util/logger.LEVELS} level
+ * @returns {boolean}
+ */
+Logger.prototype._isError = function (level) {
+    if  (LOG_LEVELS[this.errorLevel] >= LOG_LEVELS[level]) {
+        this.loggedErrors++;
+        return true;
+    }
+    return false;
+};
+
+/**
+ * Invoke one of the logger handlers: debug, info, fatal, warn...
+ * @private
+ * @param {module:jsdoc/util/logger.LEVELS} level
+ * @param logArgs
+ */
+Logger.prototype._invoke = function (level, logArgs) {
+    var eventName = 'logger:' + LEVELS[level].toLowerCase();
+    var handler = this._getHandler(level);
+
+    if (_.isFunction(handler) && this._canBeLogged(level)) {
+        handler.apply(this, addPrefix(logArgs, level));
+    }
+
+
+    if (this._isFatal(level)) {
+        /**
+         * Fatal event.
+         * @event module:jsdoc/util/logger#fatal
+         */
+        this.emit('fatal');
+    }
+
+    this.errors || this._isError(level);
+
+    logArgs.unshift(eventName);
+    this.emit.apply(this, logArgs);
+};
+
+/**
+ * Get the log handler attached to a specific log level.
+ * @private
+ * @param {module:jsdoc/util/logger.LEVELS} level
+ * @returns {Function}
+ */
+Logger.prototype._getHandler = function (level) {
+    return this.handlers[level];
+};
+
+
+/**
+ * Attach a log handler to a specific log level.
+ * @param {module:jsdoc/util/logger.LEVELS}level
+ * @param {Function} handler
+ * @param [context]
+ */
+Logger.prototype.setHandler = function (level, handler, context) {
+    this.handlers[level] = handler.bind(context || this);
+};
+
+/**
+ * Attach multiple log handlers at once.
+ * @param {Array} handlers
+ */
+Logger.prototype.setHandlers = function (handlers) {
+    handlers.forEach(function (handlerObj) {
+        this.setHandler(handlerObj.level, handlerObj.handler, handlerObj.context);
+    }, this);
+};
+
+/**
+ * Set console.* functions as default handlers.
+ */
+Logger.prototype.setDefaultHandlers = function () {
+    if (typeof console === 'object') {
+        this.setHandlers([
+            { level: LEVELS.VERBOSE, handler: console.info },
+            { level: LEVELS.DEBUG, handler: console.info },
+            { level: LEVELS.INFO, handler: console.info },
+            { level: LEVELS.WARN, handler: console.warn },
+            { level: LEVELS.ERROR, handler: console.error },
+            { level: LEVELS.FATAL, handler: console.error }
+        ]);
+    }
+};
+
+/**
+ * Mute the logger.
+ */
+Logger.prototype.mute = function () {
+    this.setLevel(LEVELS.SILENT);
+};
+
+/**
+ * Enable the pedantic mode.
+ */
+Logger.prototype.enablePedanticMode = function () {
+    this.fatalLevel = LEVELS.ERROR;
+    this.errorLevel = LEVELS.WARN;
+};
+
+/**
+ * Disable the pedantic mode.
+ */
+Logger.prototype.disablePedanticMode = function () {
+    this.fatalLevel = LEVELS.FATAL;
+    this.errorLevel = LEVELS.ERROR;
+};
+
+/**
+ * Check if errors were thrown
+ */
+Logger.prototype.hasErrors = function () {
+    return !!this.loggedErrors;
+};
+
+/**
+ * Check if errors were thrown
+ */
+Logger.prototype.resetErrors = function () {
+    this.loggedErrors = 0;
+};
+
+var logger = module.exports = new Logger();
+
+logger.setDefaultHandlers();

--- a/test/runner.js
+++ b/test/runner.js
@@ -51,8 +51,6 @@ var runNextFolder = module.exports = function(callback) {
     }
     else {
         process.nextTick(function() {
-            // reset the number of logged errors
-            logger.resetErrors();
             testsCompleteCallback(null, failedCount);
         });
     }

--- a/test/runner.js
+++ b/test/runner.js
@@ -44,13 +44,15 @@ var runNextFolder = module.exports = function(callback) {
     testsCompleteCallback = testsCompleteCallback || callback;
 
     // silence the logger while we run the tests
-    logger.setLevel(logger.LEVELS.SILENT);
+    logger.mute();
 
     if (index < specFolders.length) {
         jasmine.executeSpecsInFolder(specFolders[index], onComplete, opts);
     }
     else {
         process.nextTick(function() {
+            // reset the number of logged errors
+            logger.resetErrors();
             testsCompleteCallback(null, failedCount);
         });
     }

--- a/test/specs/jsdoc/util/logger.js
+++ b/test/specs/jsdoc/util/logger.js
@@ -12,7 +12,6 @@ describe('jsdoc/util/logger', function() {
 
     afterEach(function () {
         logger.setLevel(this.oldLogLevel);
-        logger.resetErrors();
     });
 
     it('should exist', function() {
@@ -430,70 +429,4 @@ describe('jsdoc/util/logger', function() {
         });
     });
 
-    describe('hasErrors', function () {
-        it('should return false if no errors were thrown', function () {
-            expect(logger.hasErrors()).toBe(false);
-            logger.info(loggerArgs);
-            expect(logger.hasErrors()).toBe(false);
-            logger.warn(loggerArgs);
-            expect(logger.hasErrors()).toBe(false);
-        });
-
-        it('should return true if an error was thrown', function () {
-            logger.error(loggerArgs);
-            expect(logger.hasErrors()).toBe(true);
-        });
-
-        it('should return true if a fatal error was thrown', function () {
-            logger.fatal(loggerArgs);
-            expect(logger.hasErrors()).toBe(true);
-        });
-    });
-
-    describe('resetErrors', function () {
-        it('should reset the number of errors to 0', function () {
-            logger.error(loggerArgs);
-            expect(logger.hasErrors()).toBe(true);
-            logger.resetErrors();
-            expect(logger.hasErrors()).toBe(false);
-        });
-    });
-
-    describe('Fatal Event', function () {
-        it('should not emit a fatal event when an error is logged', function () {
-            var fatalEventSpy = jasmine.createSpy();
-            logger.on('fatal', fatalEventSpy);
-            logger.error(loggerArgs);
-            expect(fatalEventSpy).not.toHaveBeenCalled();
-        });
-
-        it('should emit a fatal event when a fatal error is logged', function () {
-            var fatalEventSpy = jasmine.createSpy();
-            logger.on('fatal', fatalEventSpy);
-            logger.fatal(loggerArgs);
-            expect(fatalEventSpy).toHaveBeenCalled();
-        });
-    });
-
-    describe('enablePedanticMode', function () {
-        beforeEach(function () {
-            logger.enablePedanticMode();
-        });
-        afterEach(function () {
-            logger.disablePedanticMode();
-        });
-        it('should consider warnings as errors', function () {
-            logger.info(loggerArgs);
-            expect(logger.hasErrors()).toBe(false);
-            logger.warn(loggerArgs);
-            expect(logger.hasErrors()).toBe(true);
-        });
-
-        it('should consider errors as fatal errors', function () {
-            var fatalEventSpy = jasmine.createSpy();
-            logger.on('fatal', fatalEventSpy);
-            logger.error(loggerArgs);
-            expect(fatalEventSpy).toHaveBeenCalled();
-        });
-    });
 });

--- a/test/specs/jsdoc/util/logger.js
+++ b/test/specs/jsdoc/util/logger.js
@@ -5,6 +5,16 @@ describe('jsdoc/util/logger', function() {
 
     var loggerArgs = ['foo bar %s', 'hello'];
 
+
+    beforeEach(function () {
+        this.oldLogLevel = logger.getLevel();
+    });
+
+    afterEach(function () {
+        logger.setLevel(this.oldLogLevel);
+        logger.resetErrors();
+    });
+
     it('should exist', function() {
         expect(logger).toBeDefined();
         expect(typeof logger).toBe('object');
@@ -87,6 +97,19 @@ describe('jsdoc/util/logger', function() {
         expect(args[1]).toBe(loggerArgs[1]);
     }
 
+    function loggerMethodIsCalled(methodLevel, level) {
+        var handlerSpy = spyOn(logger.handlers, methodLevel);
+        logger.setLevel(level);
+        logger[methodLevel.toLowerCase()](loggerArgs);
+        expect(handlerSpy).toHaveBeenCalledWith(loggerArgs);
+    }
+    function loggerMethodIsNotCalled(methodLevel, level) {
+        var handlerSpy = spyOn(logger.handlers, methodLevel);
+        logger.setLevel(level);
+        logger[methodLevel.toLowerCase()](loggerArgs);
+        expect(handlerSpy).not.toHaveBeenCalledWith(loggerArgs);
+    }
+
     describe('debug', function() {
         var methodName = 'debug';
 
@@ -96,6 +119,36 @@ describe('jsdoc/util/logger', function() {
 
         it('should pass its arguments to listeners', function() {
             eventGetsArguments(methodName);
+        });
+
+        describe('Log Levels', function () {
+            it("should call its handler if the log level is VERBOSE", function () {
+                loggerMethodIsCalled(logger.LEVELS.DEBUG, logger.LEVELS.VERBOSE);
+            });
+
+            it("should call its handler if the log level is DEBUG", function () {
+                loggerMethodIsCalled(logger.LEVELS.DEBUG, logger.LEVELS.DEBUG);
+            });
+
+            it("should not call its handler if the log level is INFO", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.DEBUG, logger.LEVELS.INFO);
+            });
+
+            it("should not call its handler if the log level is WARN", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.DEBUG, logger.LEVELS.WARN);
+            });
+
+            it("should not call its handler if the log level is ERROR", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.DEBUG, logger.LEVELS.ERROR);
+            });
+
+            it("should not call its handler if the log level is FATAL", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.DEBUG, logger.LEVELS.FATAL);
+            });
+
+            it("should not call its handler if the log level is SILENT", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.DEBUG, logger.LEVELS.SILENT);
+            });
         });
     });
 
@@ -109,6 +162,36 @@ describe('jsdoc/util/logger', function() {
         it('should pass its arguments to listeners', function() {
             eventGetsArguments(methodName);
         });
+
+        describe('Log Levels', function () {
+            it("should call its handler if the log level is VERBOSE", function () {
+                loggerMethodIsCalled(logger.LEVELS.ERROR, logger.LEVELS.VERBOSE);
+            });
+
+            it("should call its handler if the log level is DEBUG", function () {
+                loggerMethodIsCalled(logger.LEVELS.ERROR, logger.LEVELS.DEBUG);
+            });
+
+            it("should not call its handler if the log level is INFO", function () {
+                loggerMethodIsCalled(logger.LEVELS.ERROR, logger.LEVELS.INFO);
+            });
+
+            it("should not call its handler if the log level is WARN", function () {
+                loggerMethodIsCalled(logger.LEVELS.ERROR, logger.LEVELS.WARN);
+            });
+
+            it("should not call its handler if the log level is ERROR", function () {
+                loggerMethodIsCalled(logger.LEVELS.ERROR, logger.LEVELS.ERROR);
+            });
+
+            it("should not call its handler if the log level is FATAL", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.ERROR, logger.LEVELS.FATAL);
+            });
+
+            it("should not call its handler if the log level is SILENT", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.ERROR, logger.LEVELS.SILENT);
+            });
+        });
     });
 
     describe('fatal', function() {
@@ -120,6 +203,36 @@ describe('jsdoc/util/logger', function() {
 
         it('should pass its arguments to listeners', function() {
             eventGetsArguments(methodName);
+        });
+
+        describe('Log Levels', function () {
+            it("should call its handler if the log level is VERBOSE", function () {
+                loggerMethodIsCalled(logger.LEVELS.FATAL, logger.LEVELS.VERBOSE);
+            });
+
+            it("should call its handler if the log level is DEBUG", function () {
+                loggerMethodIsCalled(logger.LEVELS.FATAL, logger.LEVELS.DEBUG);
+            });
+
+            it("should not call its handler if the log level is INFO", function () {
+                loggerMethodIsCalled(logger.LEVELS.FATAL, logger.LEVELS.INFO);
+            });
+
+            it("should not call its handler if the log level is WARN", function () {
+                loggerMethodIsCalled(logger.LEVELS.FATAL, logger.LEVELS.WARN);
+            });
+
+            it("should not call its handler if the log level is ERROR", function () {
+                loggerMethodIsCalled(logger.LEVELS.FATAL, logger.LEVELS.ERROR);
+            });
+
+            it("should not call its handler if the log level is FATAL", function () {
+                loggerMethodIsCalled(logger.LEVELS.FATAL, logger.LEVELS.FATAL);
+            });
+
+            it("should not call its handler if the log level is SILENT", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.FATAL, logger.LEVELS.SILENT);
+            });
         });
     });
 
@@ -139,6 +252,36 @@ describe('jsdoc/util/logger', function() {
         it('should pass its arguments to listeners', function() {
             eventGetsArguments(methodName);
         });
+
+        describe('Log Levels', function () {
+            it("should call its handler if the log level is VERBOSE", function () {
+                loggerMethodIsCalled(logger.LEVELS.INFO, logger.LEVELS.VERBOSE);
+            });
+
+            it("should call its handler if the log level is DEBUG", function () {
+                loggerMethodIsCalled(logger.LEVELS.INFO, logger.LEVELS.DEBUG);
+            });
+
+            it("should not call its handler if the log level is INFO", function () {
+                loggerMethodIsCalled(logger.LEVELS.INFO, logger.LEVELS.INFO);
+            });
+
+            it("should not call its handler if the log level is WARN", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.INFO, logger.LEVELS.WARN);
+            });
+
+            it("should not call its handler if the log level is ERROR", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.INFO, logger.LEVELS.ERROR);
+            });
+
+            it("should not call its handler if the log level is FATAL", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.INFO, logger.LEVELS.FATAL);
+            });
+
+            it("should not call its handler if the log level is SILENT", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.INFO, logger.LEVELS.SILENT);
+            });
+        });
     });
 
     describe('LEVELS', function() {
@@ -153,13 +296,6 @@ describe('jsdoc/util/logger', function() {
             expect(LEVELS.SILENT).toBeDefined();
         });
 
-        it('should weight the logging levels correctly relative to one another', function() {
-            expect(LEVELS.VERBOSE).toBeGreaterThan(LEVELS.DEBUG);
-            expect(LEVELS.DEBUG).toBeGreaterThan(LEVELS.INFO);
-            expect(LEVELS.INFO).toBeGreaterThan(LEVELS.WARN);
-            expect(LEVELS.WARN).toBeGreaterThan(LEVELS.ERROR);
-            expect(LEVELS.ERROR).toBeGreaterThan(LEVELS.SILENT);
-        });
     });
 
     describe('setLevel', function() {
@@ -185,6 +321,36 @@ describe('jsdoc/util/logger', function() {
         it('should pass its arguments to listeners', function() {
             eventGetsArguments(methodName);
         });
+
+        describe('Log Levels', function () {
+            it("should call its handler if the log level is VERBOSE", function () {
+                loggerMethodIsCalled(logger.LEVELS.VERBOSE, logger.LEVELS.VERBOSE);
+            });
+
+            it("should call its handler if the log level is DEBUG", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.VERBOSE, logger.LEVELS.DEBUG);
+            });
+
+            it("should not call its handler if the log level is INFO", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.VERBOSE, logger.LEVELS.INFO);
+            });
+
+            it("should not call its handler if the log level is WARN", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.VERBOSE, logger.LEVELS.WARN);
+            });
+
+            it("should not call its handler if the log level is ERROR", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.VERBOSE, logger.LEVELS.ERROR);
+            });
+
+            it("should not call its handler if the log level is FATAL", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.VERBOSE, logger.LEVELS.FATAL);
+            });
+
+            it("should not call its handler if the log level is SILENT", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.VERBOSE, logger.LEVELS.SILENT);
+            });
+        });
     });
 
     describe('warn', function() {
@@ -196,6 +362,138 @@ describe('jsdoc/util/logger', function() {
 
         it('should pass its arguments to listeners', function() {
             eventGetsArguments(methodName);
+        });
+
+        describe('Log Levels', function () {
+            it("should call its handler if the log level is VERBOSE", function () {
+                loggerMethodIsCalled(logger.LEVELS.WARN, logger.LEVELS.VERBOSE);
+            });
+
+            it("should call its handler if the log level is DEBUG", function () {
+                loggerMethodIsCalled(logger.LEVELS.WARN, logger.LEVELS.DEBUG);
+            });
+
+            it("should not call its handler if the log level is INFO", function () {
+                loggerMethodIsCalled(logger.LEVELS.WARN, logger.LEVELS.INFO);
+            });
+
+            it("should not call its handler if the log level is WARN", function () {
+                loggerMethodIsCalled(logger.LEVELS.WARN, logger.LEVELS.WARN);
+            });
+
+            it("should not call its handler if the log level is ERROR", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.WARN, logger.LEVELS.ERROR);
+            });
+
+            it("should not call its handler if the log level is FATAL", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.WARN, logger.LEVELS.FATAL);
+            });
+
+            it("should not call its handler if the log level is SILENT", function () {
+                loggerMethodIsNotCalled(logger.LEVELS.WARN, logger.LEVELS.SILENT);
+            });
+        });
+    });
+
+    describe('setHandler', function () {
+        it('should override the default log handler', function () {
+            var spy = jasmine.createSpy();
+            logger.setLevel(logger.LEVELS.WARN);
+            logger.setHandler(logger.LEVELS.ERROR, spy);
+            logger.error(loggerArgs);
+            expect(spy).toHaveBeenCalled();
+            logger.mute();
+        });
+    });
+
+    describe('setHandlers', function () {
+        it('should override the default log handlers', function () {
+            var spyInfo = jasmine.createSpy('info');
+            var spyDebug = jasmine.createSpy('debug');
+            var spyFatal = jasmine.createSpy('fatal');
+            logger.setHandlers([
+                { level: logger.LEVELS.DEBUG, handler: spyDebug },
+                { level: logger.LEVELS.INFO, handler: spyInfo },
+                { level: logger.LEVELS.FATAL, handler: spyFatal }
+            ]);
+            logger.setLevel(logger.LEVELS.VERBOSE);
+
+            logger.info(loggerArgs);
+            expect(spyInfo).toHaveBeenCalled();
+            expect(spyDebug).not.toHaveBeenCalled();
+            expect(spyFatal).not.toHaveBeenCalled();
+            logger.debug(loggerArgs);
+            expect(spyDebug).toHaveBeenCalled();
+            logger.fatal(loggerArgs);
+            expect(spyFatal).toHaveBeenCalled();
+            logger.mute();
+        });
+    });
+
+    describe('hasErrors', function () {
+        it('should return false if no errors were thrown', function () {
+            expect(logger.hasErrors()).toBe(false);
+            logger.info(loggerArgs);
+            expect(logger.hasErrors()).toBe(false);
+            logger.warn(loggerArgs);
+            expect(logger.hasErrors()).toBe(false);
+        });
+
+        it('should return true if an error was thrown', function () {
+            logger.error(loggerArgs);
+            expect(logger.hasErrors()).toBe(true);
+        });
+
+        it('should return true if a fatal error was thrown', function () {
+            logger.fatal(loggerArgs);
+            expect(logger.hasErrors()).toBe(true);
+        });
+    });
+
+    describe('resetErrors', function () {
+        it('should reset the number of errors to 0', function () {
+            logger.error(loggerArgs);
+            expect(logger.hasErrors()).toBe(true);
+            logger.resetErrors();
+            expect(logger.hasErrors()).toBe(false);
+        });
+    });
+
+    describe('Fatal Event', function () {
+        it('should not emit a fatal event when an error is logged', function () {
+            var fatalEventSpy = jasmine.createSpy();
+            logger.on('fatal', fatalEventSpy);
+            logger.error(loggerArgs);
+            expect(fatalEventSpy).not.toHaveBeenCalled();
+        });
+
+        it('should emit a fatal event when a fatal error is logged', function () {
+            var fatalEventSpy = jasmine.createSpy();
+            logger.on('fatal', fatalEventSpy);
+            logger.fatal(loggerArgs);
+            expect(fatalEventSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('enablePedanticMode', function () {
+        beforeEach(function () {
+            logger.enablePedanticMode();
+        });
+        afterEach(function () {
+            logger.disablePedanticMode();
+        });
+        it('should consider warnings as errors', function () {
+            logger.info(loggerArgs);
+            expect(logger.hasErrors()).toBe(false);
+            logger.warn(loggerArgs);
+            expect(logger.hasErrors()).toBe(true);
+        });
+
+        it('should consider errors as fatal errors', function () {
+            var fatalEventSpy = jasmine.createSpy();
+            logger.on('fatal', fatalEventSpy);
+            logger.error(loggerArgs);
+            expect(fatalEventSpy).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
- Add a logger class that can be extended in the future (for named loggers for example).
- By defaults, handlers (debug, info, error, warn...) are attached to console.\* functions if console is defined.
- Handlers can be overridden wit the setHandlers method.
- The pedantic mode is handled internally. The logic has been removed from cli.js
- Come with a lot of tests
