### PR TITLE
Use dashes instead of underscore in file names

### DIFF
--- a/lib/jsdoc/util/templateHelper.js
+++ b/lib/jsdoc/util/templateHelper.js
@@ -121,7 +121,7 @@ var getUniqueFilename = exports.getUniqueFilename = function(str) {
         // use - instead of : in namespace prefixes
         .replace(new RegExp('^(' + namespaces + '):'), '$1-')
         // replace characters that can cause problems on some filesystems
-        .replace(/[\\\/?*:|'"<>]/g, '_')
+        .replace(/[\\\/?*:|'"<>]/g, '-')
         // use - instead of ~ to denote 'inner'
         .replace(/~/g, '-')
         // use _ instead of # to denote 'instance'

--- a/test/specs/jsdoc/util/templateHelper.js
+++ b/test/specs/jsdoc/util/templateHelper.js
@@ -204,12 +204,12 @@ describe("jsdoc/util/templateHelper", function() {
 
         it('should replace slashes with underscores', function() {
             var filename = helper.getUniqueFilename('tick/tock');
-            expect(filename).toBe('tick_tock.html');
+            expect(filename).toBe('tick-tock.html');
         });
 
         it('should replace other problematic characters with underscores', function() {
             var filename = helper.getUniqueFilename('a very strange \\/?*:|\'"<> filename');
-            expect(filename).toBe('a very strange __________ filename.html');
+            expect(filename).toBe('a very strange ---------- filename.html');
         });
 
         it('should not allow a filename to start with an underscore', function() {
@@ -246,7 +246,7 @@ describe("jsdoc/util/templateHelper", function() {
 
             expect(filenameEvent).toBe('event-userDidSomething.html');
             expect(filenameExternal).toBe('external-NotInThisPackage.html');
-            expect(filenameModule).toBe('module-some_sort_of_module.html');
+            expect(filenameModule).toBe('module-some-sort-of-module.html');
             expect(filenamePackage).toBe('package-node-solve-all-your-problems.html');
         });
 
@@ -1549,7 +1549,7 @@ describe("jsdoc/util/templateHelper", function() {
                 },
                 url = helper.createLink(mockDoclet);
 
-            expect(url).toEqual('ns1._!_.html#%22*foo%22');
+            expect(url).toEqual('ns1.-!-.html#%22*foo%22');
         });
 
         it('should create a url for a function that is the only symbol exported by a module.',

--- a/test/specs/jsdoc/util/templateHelper.js
+++ b/test/specs/jsdoc/util/templateHelper.js
@@ -202,12 +202,12 @@ describe("jsdoc/util/templateHelper", function() {
             expect(filename).toBe('BackusNaur.html');
         });
 
-        it('should replace slashes with underscores', function() {
+        it('should replace slashes with dashes', function() {
             var filename = helper.getUniqueFilename('tick/tock');
             expect(filename).toBe('tick-tock.html');
         });
 
-        it('should replace other problematic characters with underscores', function() {
+        it('should replace other problematic characters with dashes', function() {
             var filename = helper.getUniqueFilename('a very strange \\/?*:|\'"<> filename');
             expect(filename).toBe('a very strange ---------- filename.html');
         });


### PR DESCRIPTION
I would like the file names to use dashes instead of underscores because then Google will index the URLs better.

"The short answer is that you should use a hyphen for your SEO URLs. Google treats a hyphen as a word separator, but does not treat an underscore that way. " http://www.ecreativeim.com/blog/2011/03/seo-basics-hyphen-or-underscore-for-seo-urls/

"We recommend that you use hyphens (-) instead of underscores (_) in your URLs." https://support.google.com/webmasters/answer/76329?hl=en