### PR TITLE
Add support for a `markdown.hardwrap` config property

### DIFF
--- a/lib/jsdoc/util/markdown.js
+++ b/lib/jsdoc/util/markdown.js
@@ -97,6 +97,10 @@ function getParseFunction(parserName, conf) {
     conf = conf || {};
 
     if (parserName === parserNames.marked) {
+        if (conf.hardwrap) {
+            marked.setOptions({breaks: true});
+        }
+
         // Marked generates an "id" attribute for headers; this custom renderer suppresses it
         markedRenderer = new marked.Renderer();
 

--- a/test/specs/jsdoc/util/markdown.js
+++ b/test/specs/jsdoc/util/markdown.js
@@ -97,5 +97,13 @@ describe('jsdoc/util/markdown', function() {
 
             expect(parser(markdownText)).toBe(convertedText);
         });
+        
+        it('should hardwrap new lines when hardwrap is enabled', function() {
+            var storage = setMarkdownConf({hardwrap: true});
+            var parser = markdown.getParser();
+
+            expect(parser('line one\nline two')).toEqual(
+                '<p>line one<br>line two</p>');
+        });
     });
 });


### PR DESCRIPTION
This fixes https://github.com/jsdoc3/jsdoc/pull/529