### PR TITLE
Added option to use longnames in navigation to default template

### DIFF
--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -300,7 +300,14 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                 itemsNav += '<li>' + linktoFn('', item.name) + '</li>';
             }
             else if ( !hasOwnProp.call(itemsSeen, item.longname) ) {
-                itemsNav += '<li>' + linktoFn(item.longname, item.name.replace(/^module:/, '')) + '</li>';
+                var displayName;
+                if (env.conf.templates.default.useLongnameInNav) {
+                    displayName = item.longname;
+                } else {
+                    displayName = item.name;
+                }
+                itemsNav += '<li>' + linktoFn(item.longname, displayName.replace(/\b(module|event):/g, '')) + '</li>';
+
                 itemsSeen[item.longname] = true;
             }
         });


### PR DESCRIPTION
Currently, only the names of the symbols themselves are shown in the navigation. However this is confusing and results in ambiguous names in larger projects. So I'd like to add an option to show the full namepath instead.