### PR TITLE
don't bail on nodeToValue when node is null

### DIFF
--- a/lib/jsdoc/src/astnode.js
+++ b/lib/jsdoc/src/astnode.js
@@ -110,6 +110,10 @@ var nodeToValue = exports.nodeToValue = function(node) {
     var str;
     var tempObject;
 
+    if (!node) {
+      node = {};
+    }
+
     switch (node.type) {
         case Syntax.ArrayExpression:
             tempObject = [];

--- a/test/specs/jsdoc/src/astnode.js
+++ b/test/specs/jsdoc/src/astnode.js
@@ -585,6 +585,7 @@ describe('jsdoc/src/astNode', function() {
         });
 
         it('should return an empty string for all other nodes', function() {
+            expect( astNode.nodeToValue(null) ).toBe('');
             expect( astNode.nodeToValue(binaryExpression) ).toBe('');
         });
     });


### PR DESCRIPTION
Not sure if this is the correct approach, but this code:
```js
export default function () { }
```

Results in a `null` value being sent to `nodeToValue`, which blows up on the switch statement within.

This update resolves the symptom (you already have behavior for returning '' on unknown nodes so it seems correct), but I don't know if the underlying cause needs more attention?