### PR TITLE
Remove whitespace from around object name

### DIFF
--- a/templates/default/tmpl/container.tmpl
+++ b/templates/default/tmpl/container.tmpl
@@ -22,10 +22,10 @@
 <header>
     <?js if (!doc.longname || doc.kind !== 'module') { ?>
         <h2><?js if (doc.ancestors && doc.ancestors.length) { ?>
-            <span class="ancestors"><?js= doc.ancestors.join('') ?></span>
-        <?js } ?>
-        <?js= doc.name ?>
-        <?js if (doc.variation) { ?>
+            <span class="ancestors"><?js= doc.ancestors.join('') ?></span><?js
+         } 
+        ?><?js= doc.name ?><?js
+         if (doc.variation) { ?>
             <sup class="variation"><?js= doc.variation ?></sup>
         <?js } ?></h2>
         <?js if (doc.classdesc) { ?>


### PR DESCRIPTION
Prevents unnecessary space between ancestors and object name.

Could also just use: 
 
`25 | `` `` `` ``<span class="ancestors"><?js= doc.ancestors.join('') ?></span><?js `