### PR TITLE
Adding iconv support

### DIFF
--- a/jsdoc.js
+++ b/jsdoc.js
@@ -83,7 +83,11 @@ global.app = (function() {
     var logger = require('./lib/jsdoc/util/logger');
     var runtime = require('./lib/jsdoc/util/runtime');
     var cli = require('./cli');
-
+    var iconv = require('iconv-lite');
+    
+    // Add more encodings
+    iconv.extendNodeEncodings();
+    
     function cb(errorCode) {
         cli.logFinish();
         cli.exit(errorCode || 0);
@@ -133,4 +137,5 @@ global.app = (function() {
     else {
         cli.runCommand(cb);
     }
+    iconv.undoExtendNodeEncodings();
 })();

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "strip-json-comments": "~1.0.2",
     "taffydb": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
     "underscore": "~1.7.0",
-    "wrench": "~1.5.8"
+    "wrench": "~1.5.8",
+    "iconv-lite": ">0.4.2"
   },
   "devDependencies": {
     "eslint": "~0.13.0",


### PR DESCRIPTION
Adding iconv-lite modul and all encoders from it.
Now I can use not built-in encoders like win1251 and others.