### PR TITLE
Hotfix for error

### DIFF
--- a/templates/haruki/publish.js
+++ b/templates/haruki/publish.js
@@ -211,7 +211,8 @@ exports.publish = function(data, opts) {
             console.log( xml('jsdoc', root) );
         }
         else {
-            global.dump(root);
+            // global.dump(root);
+            console.log(root);
         }
     }
     else {


### PR DESCRIPTION
Hotfix to prevent an error (and get the JSON output to the console) while using Node or Rhino:

```
jsdoc somefile.js -t templates/haruki -d console -q format=json
```

The error received while using Rhino is:

```
org.mozilla.javascript.EcmaError: TypeError: Cannot find function dump in object
 [object JavaImporter].
        at org.mozilla.javascript.ScriptRuntime.constructError(ScriptRuntime.jav
a:3689)
        at org.mozilla.javascript.ScriptRuntime.constructError(ScriptRuntime.jav
a:3667)
        at org.mozilla.javascript.ScriptRuntime.typeError(ScriptRuntime.java:369
5)
        at org.mozilla.javascript.ScriptRuntime.typeError2(ScriptRuntime.java:37
14)
        at org.mozilla.javascript.ScriptRuntime.notFunctionError(ScriptRuntime.j
ava:3786)
        at org.mozilla.javascript.ScriptRuntime.getPropFunctionAndThisHelper(Scr
iptRuntime.java:2268)
        at org.mozilla.javascript.ScriptRuntime.getPropFunctionAndThis(ScriptRun
time.java:2250)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_templates_haruki_publish_js_115._c_anonymous_4(Unknown Source)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_templates_haruki_publish_js_115.call(Unknown Source)
        at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:52)

        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_cli_js_21._c_anonymous_28(Unknown Source)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_cli_js_21.call(Unknown Source)
        at org.mozilla.javascript.optimizer.OptRuntime.callProp0(OptRuntime.java
:85)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_cli_js_21._c_anonymous_25(Unknown Source)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_cli_js_21.call(Unknown Source)
        at org.mozilla.javascript.optimizer.OptRuntime.callProp0(OptRuntime.java
:85)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_cli_js_21._c_anonymous_16(Unknown Source)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_cli_js_21.call(Unknown Source)
        at org.mozilla.javascript.optimizer.OptRuntime.callName0(OptRuntime.java
:74)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_cli_js_21._c_anonymous_10(Unknown Source)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_cli_js_21.call(Unknown Source)
        at org.mozilla.javascript.optimizer.OptRuntime.call1(OptRuntime.java:32)

        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_jsdoc_js_1._c_anonymous_4(Unknown Source)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_jsdoc_js_1.call(Unknown Source)
        at org.mozilla.javascript.optimizer.OptRuntime.call0(OptRuntime.java:23)

        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_jsdoc_js_1._c_script_0(Unknown Source)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_jsdoc_js_1.call(Unknown Source)
        at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:3
94)
        at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:309
0)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_jsdoc_js_1.call(Unknown Source)
        at org.mozilla.javascript.gen.file__C__Users_djthomps_Desktop_closure_sa
mple4_jsdoc_jsdoc_js_1.exec(Unknown Source)
        at org.mozilla.javascript.commonjs.module.Require.executeModuleScript(Re
quire.java:355)
        at org.mozilla.javascript.commonjs.module.Require.getExportedModuleInter
face(Require.java:288)
        at org.mozilla.javascript.commonjs.module.Require.requireMain(Require.ja
va:137)
        at org.mozilla.javascript.tools.shell.Main.processSource(Main.java:525)
        at org.mozilla.javascript.tools.shell.Main.processFiles(Main.java:176)
        at org.mozilla.javascript.tools.shell.Main$IProxy.run(Main.java:100)
        at org.mozilla.javascript.Context.call(Context.java:489)
        at org.mozilla.javascript.ContextFactory.call(ContextFactory.java:504)
        at org.mozilla.javascript.tools.shell.Main.exec(Main.java:158)
        at org.mozilla.javascript.tools.shell.Main.main(Main.java:136)
undefined
```

While using Node:

```
"C:\Program Files (x86)\JetBrains\WebStorm 10.0.3\bin\runnerw.exe" "C:\Program Files\nodejs\node.exe" jsdoc.js -c config.json ../infaButton.js -t templates/haruki -d console q format=json

ERROR: Unable to find the source file or directory c:\Users\djthomps\Desktop\closure\sample4\jsdoc\format=json
c:\Users\djthomps\Desktop\closure\sample4\jsdoc\templates\haruki\publish.js:203
            global.dump(root);
                   ^
TypeError: undefined is not a function
    at Object.exports.publish (c:\Users\djthomps\Desktop\closure\sample4\jsdoc\templates\haruki\publish.js:203:20)
    at Object.module.exports.cli.generateDocs (c:\Users\djthomps\Desktop\closure\sample4\jsdoc\cli.js:433:39)
    at Object.module.exports.cli.processParseResults (c:\Users\djthomps\Desktop\closure\sample4\jsdoc\cli.js:386:20)
    at module.exports.cli.main (c:\Users\djthomps\Desktop\closure\sample4\jsdoc\cli.js:230:14)
    at Object.module.exports.cli.runCommand (c:\Users\djthomps\Desktop\closure\sample4\jsdoc\cli.js:183:5)
    at c:\Users\djthomps\Desktop\closure\sample4\jsdoc\jsdoc.js:131:13
    at Object.<anonymous> (c:\Users\djthomps\Desktop\closure\sample4\jsdoc\jsdoc.js:133:3)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3

Process finished with exit code 1
```