### PR TITLE
Improved support for implicit @param names (#704).

### DIFF
--- a/lib/jsdoc/doclet.js
+++ b/lib/jsdoc/doclet.js
@@ -116,6 +116,26 @@ function fixDescription(docletSrc) {
     return docletSrc;
 }
 
+function expandParamNames(params, codeNames) {
+    var i;
+    var l;
+    var name;
+    var u;
+    var usedCodeName = '';
+
+    for (i = 0, u = 0, l = params.length; i < l; i++) {
+        name = params[i].name;
+
+        if (!name) {
+            usedCodeName = codeNames[u++] || '';
+            params[i].name = usedCodeName;
+        } else if (/^[\.]{1,3}([^\.].*)$/.test(name)) {
+            params[i].name = usedCodeName + '.' + RegExp.$1;
+        }
+    }
+    return params;
+}
+
 /**
  * Replace the existing tag dictionary with a new tag dictionary.
  *
@@ -157,9 +177,6 @@ var Doclet = exports.Doclet = function(docletSrc, meta) {
 
 /** Called once after all tags have been added. */
 Doclet.prototype.postProcess = function() {
-    var i;
-    var l;
-
     if (!this.preserveName) {
         jsdoc.name.resolve(this);
     }
@@ -180,11 +197,7 @@ Doclet.prototype.postProcess = function() {
 
     // add in any missing param names
     if (this.params && this.meta && this.meta.code && this.meta.code.paramnames) {
-        for (i = 0, l = this.params.length; i < l; i++) {
-            if (!this.params[i].name) {
-                this.params[i].name = this.meta.code.paramnames[i] || '';
-            }
-        }
+        this.params = expandParamNames(this.params, this.meta.code.paramnames);
     }
 };
 

--- a/test/fixtures/paramtag3.js
+++ b/test/fixtures/paramtag3.js
@@ -1,0 +1,31 @@
+/**
+ @param {object} - The options
+ @param {string} [options.something] - An option
+ @param {function} - a callback invoked on completion
+ */
+function mixedNaming(options, callback){}
+
+/**
+ @param {object} - The options
+ @param {string} .aThing - Required option
+ @param {string} [.something] - Optional option
+ @param {function} - a callback invoked on completion
+ */
+function implicitNaming(options, callback){}
+
+/**
+ @param {object} - The options
+ @param {string} ...aThing - Required option
+ @param {string} [...something] - An option
+ @param {function} - a callback invoked on completion
+ */
+function dotNaming(options, callback){}
+
+/**
+ * @param {object} - The options
+ * @param {string} ...aThing
+ * @param {object} [...extras] - Extra options
+ * @param {string} [...extras.value] - The extra value
+ * @param {function} - a callback invoked on completion
+ */
+function nestedDotNaming(options, callback){}

--- a/test/specs/tags/paramtag.js
+++ b/test/specs/tags/paramtag.js
@@ -116,4 +116,45 @@ describe('@param tag', function() {
 
         expect(test.description).not.toBeDefined();
     });
+
+    describe('without names', function() {
+        var docSet3 = jasmine.getDocSetFromFile('test/fixtures/paramtag3.js');
+
+        it('When a @param tag is named and sits in-between two unnamed @param tags, the names will be taken in-order from the code', function() {
+            var mixedNaming = docSet3.getByLongname('mixedNaming')[0];
+
+            expect(typeof mixedNaming.params).toBe('object');
+            expect(mixedNaming.params[0].name).toBe('options');
+            expect(mixedNaming.params[1].name).toBe('options.something');
+            expect(mixedNaming.params[2].name).toBe('callback');
+        });
+
+        it('When a @param tag is implicilty named and sits amongst unnamed @param tags, the code\'s names will be walked in-order', function() {
+            var func = docSet3.getByLongname('implicitNaming')[0];
+
+            expect(typeof func.params).toBe('object');
+            expect(func.params[0].name).toBe('options');
+            expect(func.params[1].name).toBe('options.aThing');
+            expect(func.params[2].name).toBe('options.something');
+            expect(func.params[3].name).toBe('callback');
+        });
+
+        it('When a @param tag is named starting with "..." and sits amongst unnamed @param tags, the code\'s names will be walked in-order', function() {
+            var basic = docSet3.getByLongname('dotNaming')[0];
+            var nested = docSet3.getByLongname('nestedDotNaming')[0];
+
+            expect(typeof basic.params).toBe('object');
+            expect(basic.params[0].name).toBe('options');
+            expect(basic.params[1].name).toBe('options.aThing');
+            expect(basic.params[2].name).toBe('options.something');
+            expect(basic.params[3].name).toBe('callback');
+
+            expect(typeof nested.params).toBe('object');
+            expect(nested.params[0].name).toBe('options');
+            expect(nested.params[1].name).toBe('options.aThing');
+            expect(nested.params[2].name).toBe('options.extras');
+            expect(nested.params[3].name).toBe('options.extras.value');
+            expect(nested.params[4].name).toBe('callback');
+        });
+    });
 });


### PR DESCRIPTION
When a `@param` is encountered with no name, the first unused code parameter name will be substituted.

The `@param` tag will now expand parameter names beginning with "." or "...". When encountered, they will be replaced with the (eventual) name of the last implicitly named `@param`.

This will support implicitly documenting function parameters as follows:

```
/**
 * Constructs the control
 * @constructor
 * @param {object} - the control configuration
 * @param {string} .configValueA - a config value
 * @param {string} .anotherValue - another config value
 * @param - the context
 */
function MyComponent(options, context) {}
```

Wherein the middle two parameters will expand to `options.configValueA` and `options.anotherValue`, and the final one will expand to `context`.