### PR TITLE
Make the markdown parser able to generate anchors for headings

### DIFF
--- a/lib/jsdoc/util/markdown.js
+++ b/lib/jsdoc/util/markdown.js
@@ -104,9 +104,11 @@ function getParseFunction(parserName, conf) {
         // Marked generates an "id" attribute for headers; this custom renderer suppresses it
         markedRenderer = new marked.Renderer();
 
-        markedRenderer.heading = function(text, level) {
-            return util.format('<h%s>%s</h%s>', level, text, level);
-        };
+        if(!conf.idInHeadings) {
+            markedRenderer.heading = function(text, level) {
+                return util.format('<h%s>%s</h%s>', level, text, level);
+            };
+        }
 
         // Allow prettyprint to work on inline code samples
         markedRenderer.code = function(code, language) {


### PR DESCRIPTION
This pull request gives the user a configuration so that he can choose to let the markdown parser add an anchor in the headings. This feature is very useful if you want to point directly to specific parts of a tutorial generated with markdown (that's my current use case).

To use the feature : set the attribute anchorInHeadings in the markdown part of the configuration file. The default is set to false.

```
{
  "markdown" : {
    "idInHeadings" : true
  }
}
```

I would have added some tests, but there seems to be none existing so far for the markdown. If it is necessary, could you give a hand in making them?

Cheers.