### PR TITLE
Fix markdown breaking namepaths w/special chars

### DIFF
--- a/lib/jsdoc/util/markdown.js
+++ b/lib/jsdoc/util/markdown.js
@@ -78,6 +78,20 @@ function escapeCode(source) {
 }
 
 /**
+ * Unencode quotes that occur within {@ ... } after the markdown parser has turned them
+ * into html entities (unfortunately it isn't possible to escape them before parsing)
+ *
+ * @param {string} source - The source text to unencode.
+ * @return {string} The source text with html entity `&quot;` converted back to standard quotes
+ */
+function unencodeQuotes(source) {
+    return source.replace(/\{@[^}\r\n]+\}/g, function (wholeMatch) {
+        return wholeMatch.replace(/&quot;/g, '"');
+    });
+}
+
+
+/**
  * Retrieve a function that accepts a single parameter containing Markdown source. The function uses
  * the specified parser to transform the Markdown source to HTML, then returns the HTML as a string.
  *
@@ -125,7 +139,9 @@ function getParseFunction(parserName, conf) {
             result = marked(source, { renderer: markedRenderer })
                 .replace(/\s+$/, '')
                 .replace(/&#39;/g, "'");
+
             result = unescapeUrls(result);
+            result = unencodeQuotes(result);
 
             return result;
         };


### PR DESCRIPTION
Fixes #1035 

See issue #1035 for a full description of the problem, cliff notes here though:

If a namepath has special characters in it (e.g. periods, hash symbol, etc), you need to quote the name that contains the special character (see http://usejsdoc.org/about-namepaths.html, section "Namepaths of objects with special characters in the name"). A short example is:
```
/** @namespace */
var chat = {
    /**
     * Refer to this by {@link chat."#channel"}.
     * @namespace
     */
    "#channel": {
    }
}
```

The `marked` parser for the markdown plugin converts the `"` character into the html entity `&quot;`, which breaks namepaths (and produces my specific issue of links not working in the generated doc).

This PR solves that by creating an `unencodeQuotes(...)` method, that grabs the `{@ ... }` tags, and reverses that conversion after the markdown parsing is done, turning `&quot;` back into `"` when found in a `{@ ... }` tag.