### PR TITLE
I added support for overriding jsdoc arguments from nodejs environment.

### DIFF
--- a/jsdoc.js
+++ b/jsdoc.js
@@ -56,6 +56,10 @@ global.env = (function() {
     }
 })();
 
+if (process && process.env && process.env.jsDocArgs) {
+    global.env.args = process.env.jsDocArgs.split(",");
+}
+
 /**
  * Data that must be shared across the entire application.
  *


### PR DESCRIPTION
I introduced a minor change which makes possible jsdoc run from js code (e.g nodejs). With the current code, it is possible to override the arguments which are going to be used when jsdoc is required.

Once I did this it was fairly easy to create a gulp plugin which uses jsdoc with all its capabilities (this is not the case for existing https://www.npmjs.com/package/gulp-jsdoc).