### PR TITLE
Update async & underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/jsdoc3/jsdoc"
   },
   "dependencies": {
-    "async": "~0.9.0",
+    "async": "^1.4.0",
     "bluebird": "~2.9.14",
     "catharsis": "~0.8.7",
     "escape-string-regexp": "~1.0.2",
@@ -23,7 +23,7 @@
     "requizzle": "~0.2.0",
     "strip-json-comments": "~1.0.2",
     "taffydb": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
-    "underscore": "~1.7.0",
+    "underscore": "~1.8.0",
     "wrench": "~1.5.8"
   },
   "devDependencies": {


### PR DESCRIPTION
No breaking changes known.

Async : [Changelog](https://github.com/caolan/async/blob/master/CHANGELOG.md) (async use strict semver, so safe to use "^")
Underscore : no changelog found, sorry