### PR TITLE
Direct link to Travis build image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 JSDoc 3
 =======
-[![Build Status](https://img.shields.io/travis/jsdoc3/jsdoc.svg)](http://travis-ci.org/jsdoc3/jsdoc)
+[![Build Status](https://travis-ci.org/jsdoc3/jsdoc.svg?branch=master)](http://travis-ci.org/jsdoc3/jsdoc)
 
 An API documentation generator for JavaScript.
 


### PR DESCRIPTION
The shields.io image kept not showing up:

![image](https://cloud.githubusercontent.com/assets/33569/8978715/89e5ed36-3659-11e5-8cf4-3e4b3e6f29b0.png)
