### PR TITLE
Fix typo in JSXMemberExpresson walker

### DIFF
--- a/lib/jsdoc/src/walker.js
+++ b/lib/jsdoc/src/walker.js
@@ -305,7 +305,7 @@ walkers[Syntax.JSXIdentifier] = leafNode;
 walkers[Syntax.JSXMemberExpression] = function(node, parent, state, cb) {
     cb(node.object, node, state);
 
-    cb(node.property. node, state);
+    cb(node.property, node, state);
 };
 
 walkers[Syntax.JSXNamespacedName] = function(node, parent, state, cb) {


### PR DESCRIPTION
This fixes an error I encountered when trying to run jsdoc on a file with a JSXMemberExpression (something like this: `<foo.bar>hello</foo.bar>`).