### PR TITLE
fix displaying of falsy default values in haruki template

### DIFF
--- a/templates/haruki/publish.js
+++ b/templates/haruki/publish.js
@@ -7,6 +7,8 @@
  */
 'use strict';
 
+var hasOwnProp = Object.prototype.hasOwnProperty;
+
 function graft(parentNode, childNodes, parentLongname, parentName) {
     childNodes
     .filter(function (element) {
@@ -83,7 +85,7 @@ function graft(parentNode, childNodes, parentLongname, parentName) {
                         'name': element.params[i].name,
                         'type': element.params[i].type? (element.params[i].type.names.length === 1? element.params[i].type.names[0] : element.params[i].type.names) : '',
                         'description': element.params[i].description || '',
-                        'default': element.params[i].defaultvalue || '',
+                        'default': hasOwnProp.call(element.params[i], 'defaultvalue') ? element.params[i].defaultvalue : '',
                         'optional': typeof element.params[i].optional === 'boolean'? element.params[i].optional : '',
                         'nullable': typeof element.params[i].nullable === 'boolean'? element.params[i].nullable : ''
                     });
@@ -138,7 +140,7 @@ function graft(parentNode, childNodes, parentLongname, parentName) {
                         'name': element.params[i].name,
                         'type': element.params[i].type? (element.params[i].type.names.length === 1? element.params[i].type.names[0] : element.params[i].type.names) : '',
                         'description': element.params[i].description || '',
-                        'default': element.params[i].defaultvalue || '',
+                        'default': hasOwnProp.call(element.params[i], 'defaultvalue') ? element.params[i].defaultvalue : '',
                         'optional': typeof element.params[i].optional === 'boolean'? element.params[i].optional : '',
                         'nullable': typeof element.params[i].nullable === 'boolean'? element.params[i].nullable : ''
                     });
@@ -180,7 +182,7 @@ function graft(parentNode, childNodes, parentLongname, parentName) {
                         'name': element.params[i].name,
                         'type': element.params[i].type? (element.params[i].type.names.length === 1? element.params[i].type.names[0] : element.params[i].type.names) : '',
                         'description': element.params[i].description || '',
-                        'default': element.params[i].defaultvalue || '',
+                        'default': hasOwnProp.call(element.params[i], 'defaultvalue') ? element.params[i].defaultvalue : '',
                         'optional': typeof element.params[i].optional === 'boolean'? element.params[i].optional : '',
                         'nullable': typeof element.params[i].nullable === 'boolean'? element.params[i].nullable : ''
                     });


### PR DESCRIPTION
When a `@param` has falsy value it's not displayed in JSON result:

```js
 /**
   * Float number in specified range.
   * @param {number} [min=0] - Minimum number in the range.
   * @param {number} [max=10] - Maximum number in the range.
   * @returns {Number}
   */
```

Result:

```json
...
{
  "name": "min",
  "type": "number",
  "description": "Minimum number in the range.",
  "default": "",
  "optional": true,
  "nullable": ""
}
...
```