### PR TITLE
Prevent output from being cut off in Node 4

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -447,11 +447,12 @@ cli.generateDocs = function() {
 
 // TODO: docs
 cli.exit = function(exitCode, message) {
-    if (message && exitCode > 0) {
-        console.error(message);
+    if (exitCode > 0) {
+        if (message) {
+            console.error(message);
+        }
+        process.exit(exitCode);
     }
-
-    process.exit(exitCode || 0);
 };
 
 return cli;


### PR DESCRIPTION
This is a quick fix for truncated output in Node 4 by only calling
`process.exit` for errors.

Closes #1070