### PR TITLE
Clean up space-after-keywords lint violations

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -81,7 +81,7 @@ cli.loadConfig = function() {
     try {
         isFile = fs.statSync(confPath).isFile();
     }
-    catch(e) {
+    catch (e) {
         isFile = false;
     }
 
@@ -423,7 +423,7 @@ cli.generateDocs = function() {
     try {
         template = require(env.opts.template + '/publish');
     }
-    catch(e) {
+    catch (e) {
         logger.fatal('Unable to load template: ' + e.message || e);
     }
 

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -122,7 +122,7 @@ global.app = (function() {
         try {
             cli.runCommand(cb);
         }
-        catch(e) {
+        catch (e) {
             if (e.rhinoException) {
                 logger.fatal( e.rhinoException.printStackTrace() );
             } else {

--- a/lib/jsdoc/path.js
+++ b/lib/jsdoc/path.js
@@ -105,7 +105,7 @@ exports.getResourcePath = function(filepath, filename) {
         try {
             fs.readdirSync(_path);
         }
-        catch(e) {
+        catch (e) {
             return false;
         }
 

--- a/lib/jsdoc/src/parser.js
+++ b/lib/jsdoc/src/parser.js
@@ -171,7 +171,7 @@ Parser.prototype.parse = function(sourceFiles, encoding) {
             try {
                 sourceCode = fs.readFileSync(filename, encoding);
             }
-            catch(err) {
+            catch (err) {
                 logger.error('Unable to read and parse the source file %s: %s', filename, err);
             }
         }

--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -84,7 +84,7 @@ function setDocletScopeToTitle(doclet, tag) {
     try {
         doclet.setScope(tag.title);
     }
-    catch(e) {
+    catch (e) {
         jsdoc.util.logger.error(e.message);
     }
 }

--- a/node/fs.js
+++ b/node/fs.js
@@ -13,7 +13,7 @@ var toDir = exports.toDir = function(_path) {
     try {
         isDirectory = fs.statSync(_path).isDirectory();
     }
-    catch(e) {
+    catch (e) {
         isDirectory = false;
     }
 

--- a/plugins/sourcetag.js
+++ b/plugins/sourcetag.js
@@ -37,7 +37,7 @@ exports.handlers = {
                 try {
                     value = JSON.parse(tag.value);
                 }
-                catch(e) {
+                catch (e) {
                     logger.error('@source tag expects a valid JSON value, like { "filename": "myfile.js", "lineno": 123 }.');
                     return;
                 }

--- a/test/lib/jasmine.js
+++ b/test/lib/jasmine.js
@@ -607,7 +607,7 @@ jasmine.XmlHttpRequest = (typeof XMLHttpRequest == "undefined") ? function() {
   function tryIt(f) {
     try {
       return f();
-    } catch(e) {
+    } catch (e) {
     }
     return null;
   }
@@ -806,7 +806,7 @@ jasmine.Env.prototype.describe = function(description, specDefinitions) {
   var declarationError = null;
   try {
     specDefinitions.call(suite);
-  } catch(e) {
+  } catch (e) {
     declarationError = e;
   }
 
@@ -1608,7 +1608,7 @@ jasmine.FakeTimer.prototype.runFunctionsWithinRange = function(oldMillis, nowMil
               funcToRun.millis,
               true);
         }
-      } catch(e) {
+      } catch (e) {
       }
     }
     this.runFunctionsWithinRange(oldMillis, nowMillis);

--- a/test/spec-collection.js
+++ b/test/spec-collection.js
@@ -54,7 +54,7 @@ function isValidSpec(file, matcher) {
             // ...be relevant to the current runtime
             file.indexOf(skipPath) === -1;
     }
-    catch(e) {
+    catch (e) {
         result = false;
     }
 


### PR DESCRIPTION
This eliminates the following when running `gulp lint`:

> error  Keyword "catch" must be followed by whitespace

Closes #1083