### PR TITLE
[bug 1091] Add guard to recurser callback when state isn't provided

### DIFF
--- a/lib/jsdoc/src/walker.js
+++ b/lib/jsdoc/src/walker.js
@@ -557,20 +557,22 @@ Walker.prototype._recurse = function(filename, ast) {
         astnode.addNodeProperties(node);
         node.parent = parent || null;
 
-        currentScope = getCurrentScope(cbState.scopes);
-        if (currentScope) {
-            node.enclosingScope = currentScope;
-        }
+        if (cbState) {
+            currentScope = getCurrentScope(cbState.scopes);
+            if (currentScope) {
+                node.enclosingScope = currentScope;
+            }
 
-        if (isScope) {
-            cbState.scopes.push(node);
-        }
-        cbState.nodes.push(node);
+            if (isScope) {
+                cbState.scopes.push(node);
+            }
+            cbState.nodes.push(node);
 
-        self._walkers[node.type](node, parent, cbState, cb);
+            self._walkers[node.type](node, parent, cbState, cb);
 
-        if (isScope) {
-            cbState.scopes.pop();
+            if (isScope) {
+                cbState.scopes.pop();
+            }
         }
     }
 


### PR DESCRIPTION
In the case of an object spread, no scope is provided to the callback function, which currently precipitates a fatal error.

Fixes https://github.com/jsdoc3/jsdoc/issues/1091