### PR TITLE
Add `require` default template module:constructors

### DIFF
--- a/templates/default/tmpl/method.tmpl
+++ b/templates/default/tmpl/method.tmpl
@@ -7,8 +7,15 @@ var self = this;
     <h2>Constructor</h2>
     <?js } ?>
 
-    <h4 class="name" id="<?js= id ?>"><?js= data.attribs + (kind === 'class' ? 'new ' : '') +
-    name + (data.signature || '') ?></h4>
+    <h4 class="name" id="<?js= id ?>"><?js= data.attribs ?><?js
+      if(kind === 'class' && name.indexOf('module:') === 0) {
+        print('new (require("' + name.slice(7) + '"))');
+      } else if(kind === 'class') {
+        print('new ' + name);
+      } else {
+        print(name);
+      }
+    ?><?js= (data.signature || '') ?></h4>
 
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>


### PR DESCRIPTION
Instead of rendering something like `new module:foo/bar()` for a
constructor aliased as a module in the default template, we can treat it
like an exposed function and render: `new (require("foo/bar"))()`.

This is consistent with how functions are rendered in the default template: https://github.com/jsdoc3/jsdoc/blob/ac7ce7c408ee360a273ad7bfa4541db0cbb68ee7/templates/default/publish.js#L283