### PR TITLE
Fix crash that affects exported anonymous classes with members

### DIFF
--- a/lib/jsdoc/src/astnode.js
+++ b/lib/jsdoc/src/astnode.js
@@ -197,9 +197,9 @@ var nodeToValue = exports.nodeToValue = function(node) {
             if (parent.type === Syntax.ClassExpression) {
                 str = nodeToValue(parent.parent);
             }
-            // otherwise, use the class's name
+            // otherwise, use the class's name (empty string if anonymous class)
             else {
-                str = nodeToValue(parent.id);
+                str = parent.id !== null ? nodeToValue(parent.id) : '';
             }
 
             if (node.kind !== 'constructor') {

--- a/test/fixtures/anonymousclass.js
+++ b/test/fixtures/anonymousclass.js
@@ -1,4 +1,16 @@
 /** @module */
 
 /** Test class */
-export default class { }
+export default class {
+  /**
+   * Construct Test instance
+   */
+  constructor () {}
+
+  /**
+   * Test method
+   */
+  test () {
+    return "test"
+  }
+}


### PR DESCRIPTION
The failure in https://github.com/jsdoc3/jsdoc/issues/1113 comes back when adding members to the anonymous class test. Will try to add a fix here if I can find out how.

As an unrelated note, it also seems that members are not documented as they should. The member `test` will not show up in docs if making this anonymous class non-anonymous.