### PR TITLE
Adding support for @return {this} so that the {this} is mapped to whatever the current class is

### DIFF
--- a/lib/jsdoc/augment.js
+++ b/lib/jsdoc/augment.js
@@ -265,6 +265,15 @@ function getInheritedAdditions(doclets, docs, documented) {
                         addDocletProperty(documented[member.longname], 'overrides',
                             members[k].longname);
                     }
+
+                    // If it is a chainable method, update the return type to be the current class rather than the
+                    // parent class
+                    if (member.chainable) {
+                        var returnsClone = doop(member.returns);
+                        returnsClone[0].type.names[0] = member.longname.split('#')[0];
+
+                        addDocletProperty(documented[member.longname], 'returns', returnsClone);
+                    }
                 }
             }
         }

--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -633,6 +633,17 @@ var baseTags = exports.baseTags = {
         canHaveType: true,
         onTagged: function(doclet, tag) {
             doclet.returns = doclet.returns || [];
+
+            // If the method is chainable (@return {this}), then change the type to be the current class
+            try {
+                if (tag.value.type.names[0] === 'this' && doclet.meta.code.name) {
+                    tag.value.type.names = [doclet.meta.code.name.split('#')[0]];
+                    doclet.chainable = true;
+                }
+            } catch (e) {
+                // Oh well, it didn't have the tag
+            }
+
             doclet.returns.push(tag.value);
         },
         synonyms: ['return']


### PR DESCRIPTION
Basically a pull request for https://github.com/jsdoc3/jsdoc/issues/991