### PR TITLE
Support an Array of tags titles in allowUnknownTags

### DIFF
--- a/lib/jsdoc/tag/validator.js
+++ b/lib/jsdoc/tag/validator.js
@@ -37,10 +37,7 @@ exports.validate = function(tag, tagDef, meta) {
     }
 
     // check for errors that make the tag useless
-    if (!tagDef && !env.conf.tags.allowUnknownTags) {
-        logger.error( buildMessage(tag.title, meta, 'is not a known tag') );
-    }
-    else if (!tag.text && tagDef.mustHaveValue) {
+    if (!tag.text && tagDef.mustHaveValue) {
         logger.error( buildMessage(tag.title, meta, 'requires a value') );
     }
 

--- a/lib/jsdoc/tag/validator.js
+++ b/lib/jsdoc/tag/validator.js
@@ -28,7 +28,10 @@ exports.validate = function(tag, tagDef, meta) {
     // handle cases where the tag definition does not exist
     if (!tagDef) {
         // log an error if unknown tags are not allowed
-        if (!env.conf.tags.allowUnknownTags) {
+        var allowUnknownTags = env.conf.tags.allowUnknownTags;
+        if (!allowUnknownTags ||
+            (Array.isArray(allowUnknownTags) &&
+             allowUnknownTags.indexOf(tag.title) < 0)) {
             logger.error( buildMessage(tag.title, meta, 'is not a known tag') );
         }
 

--- a/test/specs/jsdoc/tag/validator.js
+++ b/test/specs/jsdoc/tag/validator.js
@@ -51,8 +51,22 @@ describe('jsdoc/tag/validator', function() {
             expect(logger.error).toHaveBeenCalled();
         });
 
+        it('logs an error if the tag is not in the dictionary and conf.tags.allowUnknownTags is does not include it', function() {
+            env.conf.tags.allowUnknownTags = [];
+            validateTag(badTag);
+
+            expect(logger.error).toHaveBeenCalled();
+        });
+
         it('does not log an error if the tag is not in the dictionary and conf.tags.allowUnknownTags is true', function() {
             env.conf.tags.allowUnknownTags = true;
+            validateTag(badTag);
+
+            expect(logger.error).not.toHaveBeenCalled();
+        });
+
+        it('does not log an error if the tag is not in the dictionary and conf.tags.allowUnknownTags includes it', function() {
+            env.conf.tags.allowUnknownTags = [badTag.title];
             validateTag(badTag);
 
             expect(logger.error).not.toHaveBeenCalled();


### PR DESCRIPTION
This PR adds support for specifying an Array of tags which are unknown to JSDoc, but allowed without error.  It provides a more granular way to disable such errors while retaining the benefits of catching errant tags (e.g. typos).

The intended use case is catching errant tags when using additional tools which support tags not recognized by JSDoc (e.g. Closure Compiler and the tags discussed in #605).

It also removes a block of dead code relating to `allowUnknownTags` which I noticed while creating the PR.  The removal is made in a separate commit to ease review.

Thanks for considering,
Kevin