### PR TITLE
Create silent template

### DIFF
--- a/templates/silent/README.md
+++ b/templates/silent/README.md
@@ -1,0 +1,11 @@
+OVERVIEW
+========
+
+The `silent` template outputs nothing at all.  Why would that be useful?  Primarily for running JSDoc as a linter to check for syntax errors and unrecognized tags in documentation comments, although it may also be useful for testing or benchmarking purposes.
+
+USAGE
+=====
+
+    ./jsdoc myscript.js -t templates/silent -a all --pedantic
+
+This command exits with a non-zero exit code if any errors are encountered.  It writes nothing to disk and the only output it produces is any error messages written to `stderr`.  This command can also be used to warn about tags which are unknown to JSDoc by setting `"allowUnknownTags": false` in a configuration file.

--- a/templates/silent/publish.js
+++ b/templates/silent/publish.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+    @param {TAFFY} taffyData See <http://taffydb.com/>.
+    @param {object} opts
+    @param {Tutorial} tutorials
+ */
+exports.publish = function(taffyData, opts, tutorials) {};


### PR DESCRIPTION
This commit creates a template named `silent` which outputs nothing at all.  As discussed in the `README.md`, this can be useful when running JSDoc as a linter to check for syntax errors or unknown tags.  It may also be useful for testing or benchmarking.

The same effect can be achieved using the haruki template and redirecting the output to `/dev/null`, but that has a few downsides:

* It is non-obvious.
* It is difficult to do in scripts which must run in both `bash` and `cmd.exe` (like npm scripts).
* It is slower due to the unnecessary formatting work and output syscalls.

This template could be distributed as a third-party template, but given the tiny code size, broad applicability, and potential usefulness for tests, I thought it might make sense to include it officially.  But, if you disagree, let me know and I'll package it separately.

Thanks for considering,
Kevin