### PR TITLE
split longname only at slicechar not followed by a forward slash

### DIFF
--- a/lib/jsdoc/name.js
+++ b/lib/jsdoc/name.js
@@ -299,7 +299,7 @@ function atomize(longname, sliceChars, forcedMemberof) {
         }
     }
     else if (longname) {
-        parts = (longname.match(new RegExp('^(:?(.+)([' + sliceChars.join() + ']))?(.+?)$')) || [])
+        parts = (longname.match(new RegExp('^(:?(.+)([' + sliceChars.join() + '](?!.+/{1}.*)))?(.+?)$')) || [])
             .reverse();
         name = parts[0] || '';
         scopePunc = parts[1] || '';

--- a/test/specs/jsdoc/name.js
+++ b/test/specs/jsdoc/name.js
@@ -122,6 +122,15 @@ describe('jsdoc/name', function() {
             expect(parts.scope).toEqual('#');
         });
 
+        it('should ignore a sliceChar in folder name', function() {
+            var startName = 'lib.Panel/lib/Panel';
+            var parts = jsdoc.name.shorten(startName);
+
+            expect(parts.name).toEqual('lib.Panel/lib/Panel');
+            expect(parts.memberof).toEqual('');
+            expect(parts.scope).toEqual('');
+        });
+
         it('should work on static names', function() {
             var startName = 'elements.selected.getVisible';
             var parts = jsdoc.name.shorten(startName);


### PR DESCRIPTION
This fix enables the use of sliceChars (dot, tilde, hash) in your project's folder names and outputs the correct name in case a static module is defined inside a folder whose name contains a sliceChar. Fixes issue #1157