### PR TITLE
Fix modules appearing in classes list

### DIFF
--- a/lib/jsdoc/util/templateHelper.js
+++ b/lib/jsdoc/util/templateHelper.js
@@ -617,6 +617,11 @@ exports.getMembers = function(data) {
         return !isModuleExports(doclet);
     });
 
+    // classes that are also modules (as in AMD exports) are not classes
+    members.classes = members.classes.filter(function(doclet) {
+        return !isModuleExports(doclet);
+    });
+
     return members;
 };
 

--- a/test/specs/jsdoc/util/templateHelper.js
+++ b/test/specs/jsdoc/util/templateHelper.js
@@ -535,6 +535,9 @@ describe("jsdoc/util/templateHelper", function() {
             {kind: 'class'}, // global
             {kind: 'class', memberof: 'SomeNamespace'} // not global
         ];
+        var nonClasses = [
+            {kind: 'class', name: 'module:MyClass', longname: 'module:MyClass'} // module
+        ];
         var externals = [
             {kind: 'external', name: 'foo'}
         ];
@@ -545,6 +548,7 @@ describe("jsdoc/util/templateHelper", function() {
             {kind: 'mixin'}
         ];
         var modules = [
+            {kind: 'module', name: 'module:MyClass', longname: 'module:MyClass'},
             {kind: 'module'}
         ];
         var namespaces = [
@@ -562,7 +566,7 @@ describe("jsdoc/util/templateHelper", function() {
             {kind: 'member', name: 'module:bar', longname: 'module:bar'}
         ];
         var misc = miscGlobal.concat(miscNonGlobal);
-        var array = classes.concat(externals.concat(events.concat(mixins.concat(modules.concat(namespaces.concat(misc))))));
+        var array = classes.concat(nonClasses.concat(externals.concat(events.concat(mixins.concat(modules.concat(namespaces.concat(misc)))))));
         var data = taffy(array);
         var members = helper.getMembers(data);
 


### PR DESCRIPTION
#### Problem

Modules which return a constructor, are listed as Class and Module. Also, the template for the class overwrites the module template.
#### Reproduction

Use the expample 'Function that returns a constructor' from the JSDoc for [AMD Modules](http://usejsdoc.org/howto-amd-modules.html):

```
/**
 * A module representing a jacket.
 * @module my/jacket
 */
define('my/jacket', function() {
    /**
     * @constructor
     * @alias module:my/jacket
     */
    var Jacket = function() {
        // ...
    };

    /** Zip up the jacket. */
    Jacket.prototype.zip = function() {
        // ...
    };

    return Jacket;
});
```

Save and generate JSDoc. The generated JSDoc contains a module `my/jacket` and a class `my/jacket`. Also see, that the class description shows a strange constructor call `new module:my/jacket()`.
#### Screenshot

This is how the generated JSDoc currently looks for me:

![image](https://cloud.githubusercontent.com/assets/13930687/14117511/438467e0-f5e5-11e5-83ec-0259215937c6.png)
#### My fix

I checked the code and saw that globals which are modules get filtered out. I used the same strategy for classes. I hope that's the way to go. At least it solved the problem for me and no tests failed.
