### PR TITLE
Upgrade dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,7 +48,6 @@
         "no-caller": 2,
         "no-div-regex": 2,
         "no-else-return": 0,
-        "no-empty-label": 2,
         "no-eq-null": 2,
         "no-eval": 2,
         "no-extra-bind": 2,
@@ -156,12 +155,11 @@
         "semi": [2, "always"],
         "semi-spacing": 2,
         "sort-vars": 0,
-        "space-after-keywords": [2, "always"],
+        "keyword-spacing": 2,
         "space-before-blocks": [2, "always"],
         "space-in-brackets": 0, // TODO: enable?
         "space-in-parens": 0, // TODO: enable?
         "space-infix-ops": 2,
-        "space-return-throw-case": 2,
         "space-unary-ops": 2,
         "spaced-comment": [2, "always"],
         "wrap-regex": 0,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ gulp.task('coverage', function(cb) {
 });
 
 gulp.task('lint', function() {
-    var pipeline = gulp.src(options.lintPaths)
+    return gulp.src(options.lintPaths)
         .pipe(eslint())
         .pipe(eslint.formatEach())
         .pipe(eslint.failOnError());

--- a/lib/jsdoc/fs.js
+++ b/lib/jsdoc/fs.js
@@ -7,7 +7,7 @@
 var fs = require('fs');
 var path = require('path');
 var stream = require('stream');
-var wrench = require('wrench');
+var fse = require('fs-extra');
 
 var ls = exports.ls = function(dir, recurse, _allFiles, _path) {
     var file;
@@ -91,7 +91,7 @@ exports.mkPath = function(_path) {
         _path = _path.join('');
     }
 
-    wrench.mkdirSyncRecursive(_path);
+    fse.mkdirsSync(_path);
 };
 
 // adapted from http://procbits.com/2011/11/15/synchronous-file-copy-in-node-js
@@ -106,7 +106,7 @@ exports.copyFileSync = function(inFile, outDir, fileName) {
     var outFile = path.join( outDir, fileName || path.basename(inFile) );
     var pos = 0;
 
-    wrench.mkdirSyncRecursive(outDir);
+    fse.mkdirsSync(outDir);
     read = fs.openSync(inFile, 'r');
     write = fs.openSync(outFile, 'w');
 

--- a/lib/jsdoc/opts/args.js
+++ b/lib/jsdoc/opts/args.js
@@ -86,4 +86,5 @@ exports.get = function(name) {
     else if ( hasOwnProp.call(ourOptions, name) ) {
         return ourOptions[name];
     }
+    return undefined;
 };

--- a/lib/jsdoc/src/astnode.js
+++ b/lib/jsdoc/src/astnode.js
@@ -363,6 +363,7 @@ var getInfo = exports.getInfo = function(node) {
                     info.paramnames = getParamNames(definition.value);
                     return true;
                 }
+                return false;
             });
 
             break;

--- a/lib/jsdoc/src/handlers.js
+++ b/lib/jsdoc/src/handlers.js
@@ -299,6 +299,8 @@ function newSymbolDoclet(parser, docletSrc, e) {
 
     addDoclet(parser, newDoclet);
     e.doclet = newDoclet;
+
+    return true;
 }
 
 /**

--- a/lib/jsdoc/src/parser.js
+++ b/lib/jsdoc/src/parser.js
@@ -319,6 +319,7 @@ Parser.prototype.getBasename = function(name) {
     if (name !== undefined) {
         return name.replace(/^([$a-z_][$a-z_0-9]*).*?$/i, '$1');
     }
+    return undefined;
 };
 
 // TODO: docs

--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -132,6 +132,7 @@ function findRestParam(params) {
             restParam = param;
             return true;
         }
+        return false;
     });
 
     return restParam;

--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -175,6 +175,7 @@ function parseBorrows(doclet, tag) {
         else if (m[1]) {
             return { target: m[1] };
         }
+        return {};
     } else {
         return {};
     }

--- a/lib/jsdoc/util/markdown.js
+++ b/lib/jsdoc/util/markdown.js
@@ -153,6 +153,7 @@ function getParseFunction(parserName, conf) {
     else {
         logger.error('Unrecognized Markdown parser "%s". Markdown support is disabled.',
             parserName);
+        return undefined;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
     "js2xmlparser": "~1.0.0",
     "marked": "~0.3.5",
     "requizzle": "~0.2.1",
-    "strip-json-comments": "~1.0.4",
+    "strip-json-comments": "~2.0.1",
     "taffydb": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
     "underscore": "~1.8.3",
     "wrench": "~1.5.9"
   },
   "devDependencies": {
     "gulp": "~3.9.1",
-    "gulp-eslint": "~1.1.1",
+    "gulp-eslint": "~2.0.0",
     "gulp-json-editor": "~2.2.1",
     "istanbul": "~0.4.2",
     "tv4": "https://github.com/hegemonic/tv4/tarball/own-properties"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "strip-json-comments": "~2.0.1",
     "taffydb": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
     "underscore": "~1.8.3",
-    "wrench": "~1.5.9"
+    "fs-extra": "~0.26.7"
   },
   "devDependencies": {
     "gulp": "~3.9.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "async": "~1.5.2",
-    "bluebird": "~2.10.2",
+    "bluebird": "~3.3.4",
     "catharsis": "~0.8.7",
     "escape-string-regexp": "~1.0.5",
     "espree": "~2.2.5",

--- a/package.json
+++ b/package.json
@@ -13,24 +13,24 @@
     "url": "https://github.com/jsdoc3/jsdoc"
   },
   "dependencies": {
-    "async": "~1.4.0",
-    "bluebird": "~2.9.34",
+    "async": "~1.5.2",
+    "bluebird": "~2.10.2",
     "catharsis": "~0.8.7",
-    "escape-string-regexp": "~1.0.3",
-    "espree": "~2.2.3",
+    "escape-string-regexp": "~1.0.5",
+    "espree": "~2.2.5",
     "js2xmlparser": "~1.0.0",
-    "marked": "~0.3.4",
-    "requizzle": "~0.2.0",
-    "strip-json-comments": "~1.0.2",
+    "marked": "~0.3.5",
+    "requizzle": "~0.2.1",
+    "strip-json-comments": "~1.0.4",
     "taffydb": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
     "underscore": "~1.8.3",
-    "wrench": "~1.5.8"
+    "wrench": "~1.5.9"
   },
   "devDependencies": {
-    "gulp": "~3.9.0",
-    "gulp-eslint": "~1.0.0",
+    "gulp": "~3.9.1",
+    "gulp-eslint": "~1.1.1",
     "gulp-json-editor": "~2.2.1",
-    "istanbul": "~0.3.17",
+    "istanbul": "~0.4.2",
     "tv4": "https://github.com/hegemonic/tv4/tarball/own-properties"
   },
   "engines": {

--- a/plugins/sourcetag.js
+++ b/plugins/sourcetag.js
@@ -37,7 +37,7 @@ exports.handlers = {
                 try {
                     value = JSON.parse(tag.value);
                 }
-                catch (e) {
+                catch (ex) {
                     logger.error('@source tag expects a valid JSON value, like { "filename": "myfile.js", "lineno": 123 }.');
                     return;
                 }

--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -239,7 +239,7 @@ function generateSourceFiles(sourceFiles, encoding) {
                 code: helper.htmlsafe( fs.readFileSync(sourceFiles[file].resolved, encoding) )
             };
         }
-        catch(e) {
+        catch (e) {
             logger.error('Error while generating source file %s: %s', file, e.message);
         }
 

--- a/templates/haruki/publish.js
+++ b/templates/haruki/publish.js
@@ -1,4 +1,4 @@
-/*eslint no-nested-ternary:0, space-infix-ops: 0 */
+/* eslint no-nested-ternary:0, space-infix-ops: 0 */
 /**
     @overview Builds a tree-like JSON string from the doclet data.
     @version 0.0.3

--- a/test/jasmine-jsdoc.js
+++ b/test/jasmine-jsdoc.js
@@ -100,21 +100,21 @@ jasmine.executeSpecsInFolder = function(folder, done, opts) {
     var jasmineEnv = jasmine.initialize(done, opts.verbose);
 
     // Load the specs
-    specs.load(folder, fileMatcher, true);
+    specs.load(folder, fileMatcher, true, function() {
+        var specsList = specs.getSpecs();
+        var filename;
 
-    var specsList = specs.getSpecs();
-    var filename;
+        // Add the specs to the context
+        for (var i = 0, len = specsList.length; i < len; ++i) {
+            filename = specsList[i];
+            require(filename.path().replace(/\\/g, '/')
+                .replace(new RegExp('^' + jsdoc.env.dirname + '/test'), './')
+                .replace(/\.\w+$/, ''));
+        }
 
-    // Add the specs to the context
-    for (var i = 0, len = specsList.length; i < len; ++i) {
-        filename = specsList[i];
-        require(filename.path().replace(/\\/g, '/')
-            .replace(new RegExp('^' + jsdoc.env.dirname + '/test'), './')
-            .replace(/\.\w+$/, ''));
-    }
-
-    // Run Jasmine
-    jasmineEnv.execute();
+        // Run Jasmine
+        jasmineEnv.execute();
+    });
 };
 
 function now() {

--- a/test/spec-collection.js
+++ b/test/spec-collection.js
@@ -3,7 +3,7 @@
 var fs = require('jsdoc/fs');
 var path = require('jsdoc/path');
 var runtime = require('jsdoc/util/runtime');
-var wrench = require('wrench');
+var fse = require('fs-extra');
 
 var specs = [];
 var finalSpecs = [];
@@ -75,18 +75,25 @@ function shouldLoad(file, matcher) {
     return result;
 }
 
-exports.load = function(loadpath, matcher, clear) {
+exports.load = function(loadpath, matcher, clear, callback) {
     if (clear === true) {
         clearSpecs();
     }
 
-    var wannaBeSpecs = wrench.readdirSyncRecursive(loadpath);
-    for (var i = 0; i < wannaBeSpecs.length; i++) {
-        var file = path.join(loadpath, wannaBeSpecs[i]);
-        if ( shouldLoad(file, matcher) ) {
-            addSpec(file);
-        }
-    }
+    var wannaBeSpecs = [];
+    fse.walk(loadpath)
+      .on('data', function(spec) {
+        wannaBeSpecs.push(spec.path);
+      })
+      .on('end', function() {
+          for (var i = 0; i < wannaBeSpecs.length; i++) {
+              var file = wannaBeSpecs[i];
+              if ( shouldLoad(file, matcher) ) {
+                  addSpec(file);
+              }
+          }
+          callback();
+      });
 };
 
 exports.getSpecs = function() {

--- a/test/specs/jsdoc/util/templateHelper.js
+++ b/test/specs/jsdoc/util/templateHelper.js
@@ -1,4 +1,4 @@
-/*eslint quotes:0 */
+/* eslint quotes:0 */
 'use strict';
 
 var hasOwnProp = Object.prototype.hasOwnProperty;


### PR DESCRIPTION
Except `espree` because I don't know how to fix the breaking changes.

Started this to scratch the itch that `npm` warned that wrench was deprecated in favor of `fs-extra` but ended up going through all dependencies.