### PR TITLE
Add code to allow defining orders in tutorial.json

### DIFF
--- a/lib/jsdoc/tutorial/resolver.js
+++ b/lib/jsdoc/tutorial/resolver.js
@@ -176,6 +176,11 @@ exports.resolve = function() {
             current.title = item.title;
         }
 
+        // set order
+        if (item.order) {
+            current.order = item.order;
+        }
+
         // add children
         if (item.children) {
             item.children.forEach(function(child) {
@@ -189,5 +194,9 @@ exports.resolve = function() {
                 }
             });
         }
+    });
+
+    exports.root.children.sort(function(a, b){
+      return a.order - b.order;
     });
 };


### PR DESCRIPTION
[The docs](http://usejsdoc.org/about-tutorials.html) imply that you can order the tutorials. That wasn't actually possible before. Now, you can specify a `order` attribute in the config.

Resolves #1028

----

I also took a stab at writing tests, but couldn't figure out how to test the order of an array in jasmine (that's what this project uses, right?), so I left it out of the PR. My thought for a test would be to change [this file](https://github.com/jsdoc3/jsdoc/blob/master/test/tutorials/tutorials/multiple.json) to this:

````json
{
    "test2": {
        "title": "Test 2",
        "children": ["test3", "test6"],
        "order": 2
    },
    "test3": {
        "title": "Test 3",
        "children": {
            "test4": {"title": "Test 4"}
        },
        "order": 1
    }
}
````
Then, the test would go [here](https://github.com/jsdoc3/jsdoc/blob/master/test/specs/jsdoc/tutorial/resolver.js#L190), and look something like this:

````js
        it('sorts tutorials by their order', function() {
            expect(resolver.root.children).toContainValuesInOrder([test3, test2]);
        });
````