### PR TITLE
add impliedStrict flag set to false fixes #1210

### DIFF
--- a/lib/jsdoc/src/astbuilder.js
+++ b/lib/jsdoc/src/astbuilder.js
@@ -89,6 +89,7 @@ var parserOptions = exports.parserOptions = {
         forOf: true,
         generators: true,
         globalReturn: true,
+        impliedStrict: false,
         jsx: true,
         modules: true,
         newTarget: true,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bluebird": "~2.9.34",
     "catharsis": "~0.8.8",
     "escape-string-regexp": "~1.0.3",
-    "espree": "~2.2.3",
+    "espree": "~3.1.4",
     "js2xmlparser": "~1.0.0",
     "marked": "~0.3.4",
     "requizzle": "~0.2.0",


### PR DESCRIPTION
This change updates the espree version to 3.1.4 and sets the
impliedStrict flag in espree to false. This will help when running
jsdoc on older code bases that are required to support older browsers.

This fixes issue  #1210 

Thanks!
