### PR TITLE
Allow comments in ES6 named export statements on class definitions.

### DIFF
--- a/lib/jsdoc/doclet.js
+++ b/lib/jsdoc/doclet.js
@@ -94,6 +94,11 @@ function unwrap(docletSrc) {
     // extra opening/closing stars are ignored
     // left margin is considered a star and a space
     // use the /m flag on regex to avoid having to guess what this platform's newline is
+
+    // note (cla): node.js' regex engine /gm interprets \r as line ending: this results in
+    // removal of the \n character on windows systems. As a workaround all whitespaces are
+    // normalized to LF before further processing
+
     docletSrc = docletSrc.replace(/\r\n/g, '\n')           // normalize whitespace
                          .replace(/^\/\*\*+/, '')          // remove opening slash+stars
                          .replace(/\**\*\/$/, '\\Z')       // replace closing star slash with end-marker

--- a/lib/jsdoc/doclet.js
+++ b/lib/jsdoc/doclet.js
@@ -94,11 +94,11 @@ function unwrap(docletSrc) {
     // extra opening/closing stars are ignored
     // left margin is considered a star and a space
     // use the /m flag on regex to avoid having to guess what this platform's newline is
-    docletSrc =
-        docletSrc.replace(/^\/\*\*+/, '') // remove opening slash+stars
-        .replace(/\**\*\/$/, '\\Z')       // replace closing star slash with end-marker
-        .replace(/^\s*(\* ?|\\Z)/gm, '')  // remove left margin like: spaces+star or spaces+end-marker
-        .replace(/\s*\\Z$/g, '');         // remove end-marker
+    docletSrc = docletSrc.replace(/\r\n/g, '\n')           // normalize whitespace
+                         .replace(/^\/\*\*+/, '')          // remove opening slash+stars
+                         .replace(/\**\*\/$/, '\\Z')       // replace closing star slash with end-marker
+                         .replace(/^\s*(\* ?|\\Z)/gm, '')  // remove left margin like: spaces+star or spaces+end-marker
+                         .replace(/\s*\\Z$/g, '');         // remove end-marker
 
     return docletSrc;
 }

--- a/lib/jsdoc/src/walker.js
+++ b/lib/jsdoc/src/walker.js
@@ -190,6 +190,11 @@ walkers[Syntax.ExportNamedDeclaration] = function(node, parent, state, cb) {
     var i;
     var l;
 
+    // if the declaration target is a class, move leading comments to the declaration target
+    if (node.declaration && node.declaration.type === Syntax.ClassDeclaration) {
+        moveComments(node, node.declaration);
+    }
+
     if (node.declaration) {
         cb(node.declaration, node, state);
     }

--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -156,7 +156,7 @@ function setDocletNameToFilename(doclet, tag) {
     if (doclet.meta.path) {
         name = filepathMinusPrefix(doclet.meta.path);
     }
-    name += doclet.meta.filename.replace(/\.js$/i, '');
+    name += doclet.meta.filename.replace(/\.jsx?$/i, '');
 
     doclet.name = name;
 }


### PR DESCRIPTION
Currently, jsdoc does not create entries for classes with a named export. The pull request fixes this, by calling moveComments for ExportNamedDeclaration.