### PR TITLE
Fixes #1249 and #961

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -410,7 +410,7 @@ cli.resolveTutorials = function() {
 cli.generateDocs = function() {
     var path = require('jsdoc/path');
     var resolver = require('jsdoc/tutorial/resolver');
-    var taffy = require('taffydb').taffy;
+    var taffy = require('taffydb-jsdoc').taffy;
 
     var template;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "marked": "~0.3.6",
     "requizzle": "~0.2.1",
     "strip-json-comments": "~2.0.1",
-    "taffydb": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
+    "taffydb-jsdoc": "2.6.2",
     "underscore": "~1.8.3"
   },
   "devDependencies": {

--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -6,7 +6,7 @@ var fs = require('jsdoc/fs');
 var helper = require('jsdoc/util/templateHelper');
 var logger = require('jsdoc/util/logger');
 var path = require('jsdoc/path');
-var taffy = require('taffydb').taffy;
+var taffy = require('taffydb-jsdoc').taffy;
 var template = require('jsdoc/template');
 var util = require('util');
 

--- a/test/specs/jsdoc/util/templateHelper.js
+++ b/test/specs/jsdoc/util/templateHelper.js
@@ -12,7 +12,7 @@ describe("jsdoc/util/templateHelper", function() {
     var helper = require('jsdoc/util/templateHelper');
     var logger = require('jsdoc/util/logger');
     var resolver = require('jsdoc/tutorial/resolver');
-    var taffy = require('taffydb').taffy;
+    var taffy = require('taffydb-jsdoc').taffy;
 
     helper.registerLink('test', 'path/to/test.html');
 


### PR DESCRIPTION
Fixes https://github.com/jsdoc3/jsdoc/issues/1249 and https://github.com/jsdoc3/jsdoc/issues/961 instead of https://github.com/jsdoc3/jsdoc/pull/1202.

@hegemonic Thank you for attention to #1202. Could you please tag a version after solving this issue? This issue (#961) prevents all environments that do not have internet access from using jsDoc. Thanks.