### PR TITLE
Feature time complexity tag

### DIFF
--- a/lib/jsdoc/schema.js
+++ b/lib/jsdoc/schema.js
@@ -543,6 +543,10 @@ var DOCLET_SCHEMA = exports.DOCLET_SCHEMA = {
             type: STRING,
             optional: true
         },
+        timecomplexity: {
+        		type: STRING,
+						optional: true
+        },
         todo: {
             type: ARRAY,
             optional: true,

--- a/lib/jsdoc/schema.js
+++ b/lib/jsdoc/schema.js
@@ -544,8 +544,8 @@ var DOCLET_SCHEMA = exports.DOCLET_SCHEMA = {
             optional: true
         },
         timecomplexity: {
-        		type: STRING,
-						optional: true
+            type: STRING,
+            optional: true
         },
         todo: {
             type: ARRAY,

--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -684,6 +684,12 @@ var baseTags = exports.baseTags = {
         },
         synonyms: ['exception']
     },
+		timecomplexity: {
+				mustHaveValue: true,
+				onTagged: function(doclet, tag) {
+						doclet.timecomplexity = tag.value;
+				}
+		},
     tutorial: {
         mustHaveValue: true,
         onTagged: function(doclet, tag) {

--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -684,12 +684,12 @@ var baseTags = exports.baseTags = {
         },
         synonyms: ['exception']
     },
-		timecomplexity: {
-				mustHaveValue: true,
-				onTagged: function(doclet, tag) {
-						doclet.timecomplexity = tag.value;
-				}
-		},
+    timecomplexity: {
+        mustHaveValue: true,
+        onTagged: function(doclet, tag) {
+            doclet.timecomplexity = tag.value;
+        }
+    },
     tutorial: {
         mustHaveValue: true,
         onTagged: function(doclet, tag) {

--- a/templates/default/tmpl/details.tmpl
+++ b/templates/default/tmpl/details.tmpl
@@ -46,6 +46,11 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     </li></ul></dd>
     <?js } ?>
 
+		<?js if (data.timecomplexity) {?>
+    <dt class="tag-timecomplexity">Time complexity:</dt>
+    <dd class="tag-timecomplexity"><ul class="dummy"><li><?js= timecomplexity ?></li></ul></dd>
+    <?js } ?>
+
     <?js if (data.implementations && data.implementations.length) { ?>
     <dt class="implementations">Implementations:</dt>
     <dd class="implementations"><ul>

--- a/templates/default/tmpl/details.tmpl
+++ b/templates/default/tmpl/details.tmpl
@@ -46,7 +46,7 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     </li></ul></dd>
     <?js } ?>
 
-		<?js if (data.timecomplexity) {?>
+    <?js if (data.timecomplexity) {?>
     <dt class="tag-timecomplexity">Time complexity:</dt>
     <dd class="tag-timecomplexity"><ul class="dummy"><li><?js= timecomplexity ?></li></ul></dd>
     <?js } ?>

--- a/test/fixtures/timecomplexitytag.js
+++ b/test/fixtures/timecomplexitytag.js
@@ -1,0 +1,6 @@
+/**
+		@timecomplexity O(n)
+*/
+function foo() {
+
+}

--- a/test/fixtures/timecomplexitytag.js
+++ b/test/fixtures/timecomplexitytag.js
@@ -1,5 +1,5 @@
 /**
-		@timecomplexity O(n)
+    @timecomplexity O(n)
 */
 function foo() {
 

--- a/test/specs/tags/timecomplexitytag.js
+++ b/test/specs/tags/timecomplexitytag.js
@@ -1,0 +1,10 @@
+'use strict';
+
+describe('@timecomplexity tag', function() {
+    var docSet = jasmine.getDocSetFromFile('test/fixtures/timecomplexitytag.js');
+    var foo = docSet.getByLongname('foo')[0];
+
+    it('When a symbol has an @timecomplexity tag, the doclet has a timecomplexity property set to true.', function() {
+        expect(foo.timecomplexity).toBe('O(n)');
+    });
+});


### PR DESCRIPTION
I added a time complexity tag, because it's a feature I often find myself wishing was present.

Example: If you have 2 data structures that preform the same tasks, but with different implementations this tag could help you choose the data structure that better fits your needs. 

Usage:
/**
  @timecomplexity O(n^2)
*/