### PR TITLE
Explicitely call exit on exit

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -448,8 +448,8 @@ cli.exit = function(exitCode, message) {
         if (message) {
             console.error(message);
         }
-        process.exit(exitCode);
     }
+    process.exit(exitCode)
 };
 
 return cli;


### PR DESCRIPTION
Hello,
I'm in the situation where I have a plugin that requires some of my files to verify that the documentation is up to date with what the code actually does. However, requiring some files opens a lot of handles (intervals, db connections...) and I cannot list them in any easy way to close them during documentation generation. This means the handles are still open and jsdoc doesn't exit when finished generating the docs. This change fixes it.
