### PR TITLE
Fixes directory name clashes with JSDoc plugin and template loading

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -313,8 +313,16 @@ function resolvePluginPaths(paths) {
 
     paths.forEach(function(plugin) {
         var basename = path.basename(plugin);
-        var dirname = plugin.split(path.sep).length > 1 ?
-            path.dirname(plugin) : undefined;
+        var dirname = path.dirname(plugin);
+
+        // support plugin specification as an installed package, which
+        // then may not have a directory component, resulting in
+        // path.dirname() to return '.', which, if passed on, would
+        // result in different path resolution semantics
+        if (dirname.indexOf('.') === 0 && plugin.indexOf('.') !== 0) {
+            dirname = undefined;
+        }
+
         var pluginPath = path.getResourcePath(dirname, basename);
 
         if (!pluginPath) {

--- a/cli.js
+++ b/cli.js
@@ -313,15 +313,16 @@ function resolvePluginPaths(paths) {
 
     paths.forEach(function(plugin) {
         var basename = path.basename(plugin);
-        var dirname = path.dirname(plugin);
-        var pluginPath = path.getResourcePath(dirname);
+        var dirname = plugin.split(path.sep).length > 1 ?
+            path.dirname(plugin) : undefined;
+        var pluginPath = path.getResourcePath(dirname, basename);
 
         if (!pluginPath) {
             logger.error('Unable to find the plugin "%s"', plugin);
             return;
         }
 
-        pluginPaths.push( path.join(pluginPath, basename) );
+        pluginPaths.push( pluginPath );
     });
 
     return pluginPaths;

--- a/lib/jsdoc/path.js
+++ b/lib/jsdoc/path.js
@@ -135,7 +135,7 @@ exports.getResourcePath = function(filepath, filename) {
 
     // Special case 'node_modules/foo', to accommodate this legacy
     // workaround advertised by 3rd party plugin and template authors
-    if (pathElems[0].indexOf('node_modules') === 0) {
+    if (pathElems[0] === 'node_modules') {
         pathElems.unshift('.');
         filepath = pathElems.join(path.sep);
     }

--- a/lib/jsdoc/path.js
+++ b/lib/jsdoc/path.js
@@ -125,6 +125,12 @@ exports.getResourcePath = function(filepath, filename) {
 
     var searchDirs = [];
 
+    // resources that are installed modules may not have been
+    // specified with a filepath
+    if (!filepath) {
+        filepath = filename;
+        filename = undefined;
+    }
     var pathElems = filepath.split(path.sep);
 
     // Special case 'node_modules/foo', to accommodate this legacy

--- a/lib/jsdoc/path.js
+++ b/lib/jsdoc/path.js
@@ -85,9 +85,21 @@ exports.commonPrefix = function(paths) {
 /**
  * Retrieve the fully qualified path to the requested resource.
  *
- * If the resource path is specified as a relative path, JSDoc searches for the path in the
- * directory where the JSDoc configuration file is located, then in the current working directory,
- * and finally in the JSDoc directory.
+ * Plugins and templates will be found somewhat similar to how
+ * require() works, except that the directory in which the JSDoc
+ * configuration file is will be considered, too, the JSDoc package
+ * directory will be considered as a fallback, and a globally
+ * installed resource won't be found unless it comes with JSDoc.
+ *
+ * If the resource path is specified as a path relative to module or
+ * package (starting with "`.`" or "`..`") JSDoc searches for the path
+ * first in the current working directory, then where the JSDoc
+ * configuration file is located, and finally as a fall-back under the
+ * JSDoc directory. Otherwise, if the resource path is relative (not
+ * starting with a path separator), JSDoc searches first under the
+ * `node_modules` directory in the current working directory and where
+ * the JSDoc configuration file is located, and then where JSDoc is
+ * installed.
  *
  * If the resource path is specified as a fully qualified path, JSDoc uses the path as-is.
  *
@@ -111,8 +123,31 @@ exports.getResourcePath = function(filepath, filename) {
         return true;
     }
 
+    var searchDirs = [];
+
+    var pathElems = filepath.split(path.sep);
+
+    // Special case 'node_modules/foo', to accommodate this legacy
+    // workaround advertised by 3rd party plugin and template authors
+    if (pathElems[0].indexOf('node_modules') === 0) {
+        pathElems.unshift('.');
+        filepath = pathElems.join(path.sep);
+    }
+
+    // search in different sets of directories depending on whether
+    // filepath is expressly relative to "current" directory or not
+    searchDirs = pathElems[0].indexOf('.') === 0 ?
+        // look first in "current" (where jsdoc was executed), then in
+        // directory of config, and _only then_ in jsdoc's directory
+        [env.pwd, path.dirname(env.opts.configure || ''), env.dirname] :
+        // otherwise, treat as relative to where plugins/templates are
+        // found, either as a dependency, or under jsdoc itself
+        [path.join(env.pwd, 'node_modules'),
+         path.join(path.dirname(env.opts.configure || ''), 'node_modules'),
+         env.dirname];
+
     // absolute paths are normalized by path.resolve on the first pass
-    [path.dirname(env.opts.configure || ''), env.pwd, env.dirname].forEach(function(_path) {
+    searchDirs.forEach(function(_path) {
         if (!result && _path) {
             _path = path.resolve(_path, filepath);
             if ( pathExists(_path) ) {

--- a/test/specs/jsdoc/path.js
+++ b/test/specs/jsdoc/path.js
@@ -201,6 +201,15 @@ describe('jsdoc/path', function() {
             expect( resolved ).not.toBeNull();
             expect( path.isAbsolute(resolved) ).toBe(true);
         });
+
+        it('resolves installed module using \'module\'', function() {
+            var p = 'marked';
+            var resolved = path.getResourcePath(undefined, p);
+
+            expect( resolved ).not.toBeNull();
+            expect( path.isAbsolute(resolved) ).toBe(true);
+        });
+
         it('leaves an absolute path as is', function() {
             var p = path.resolve([env.dirname, 'anything'].join(path.sep));
             var resolved = path.getResourcePath(path.dirname(p), 'anything');

--- a/test/specs/jsdoc/path.js
+++ b/test/specs/jsdoc/path.js
@@ -131,7 +131,82 @@ describe('jsdoc/path', function() {
         }
     });
 
-    xdescribe('getResourcePath', function() {
-        // TODO
+    describe('getResourcePath', function() {
+        var oldPwd;
+        var cwd;
+
+        beforeEach(function() {
+            oldPwd = env.pwd;
+            env.pwd = __dirname;
+            cwd = env.pwd.split(path.sep);
+        });
+
+        afterEach(function() {
+            env.pwd = oldPwd;
+        });
+
+        it('resolves package-relative path that exists', function() {
+            var resolved = path.getResourcePath('plugins');
+
+            expect( resolved ).not.toBeNull();
+            expect( path.isAbsolute(resolved) ).toBe(true);
+        });
+
+        it('fails to resolve package-relative path that exists in ./', function() {
+            var resolved = path.getResourcePath('util');
+
+            expect( resolved ).toBeNull();
+        });
+
+        it('resolves relative to ./ path that exists', function() {
+            var p = ['.', 'util'].join(path.sep);
+            var resolved = path.getResourcePath(p);
+
+            expect( resolved ).not.toBeNull();
+            expect( path.isAbsolute(resolved) ).toBe(true);
+        });
+
+        it('resolves relative to ../ path that exists', function() {
+            var p = ['..', 'jsdoc', 'util'].join(path.sep);
+            var resolved = path.getResourcePath(p);
+
+            expect( resolved ).not.toBeNull();
+            expect( path.isAbsolute(resolved) ).toBe(true);
+        });
+
+        it('resolves relative to ../ path that exists in ../ and package', function() {
+            var prel = ['..', 'plugins'].join(path.sep);
+            var pabs = 'plugins';
+            var resolved = path.getResourcePath(prel);
+
+            expect( resolved ).not.toBeNull();
+            expect( path.getResourcePath(pabs) ).not.toBeNull();
+            expect( path.isAbsolute(resolved) ).toBe(true);
+            expect( path.getResourcePath(pabs) ).not.toBe( resolved );
+        });
+
+        it('resolves relative to . path that exists in package', function() {
+            var p = ['.', 'plugins'].join(path.sep);
+            var resolved = path.getResourcePath(p);
+
+            expect( resolved ).not.toBeNull();
+            expect( path.isAbsolute(resolved) ).toBe(true);
+        });
+
+        it('resolves path using node_modules/', function() {
+            var p = ['node_modules', 'marked'].join(path.sep);
+            var resolved = path.getResourcePath(path.dirname(p),
+                                                path.basename(p));
+
+            expect( resolved ).not.toBeNull();
+            expect( path.isAbsolute(resolved) ).toBe(true);
+        });
+        it('leaves an absolute path as is', function() {
+            var p = path.resolve([env.dirname, 'anything'].join(path.sep));
+            var resolved = path.getResourcePath(path.dirname(p), 'anything');
+
+            expect( resolved ).not.toBeNull();
+            expect( p ).toEqual( resolved );
+        });
     });
 });


### PR DESCRIPTION
The issue has been reported in #1081 (and its duplicates #1097 and #1114). A fix was initially proposed by @GerHobbelt and merged in Dec 2015 (6be9dac616549ce226e4c0064876c7cb3b64fe25), only to be reverted in Sep 2016 (see [comment] and #1259 for why). Indeed, the initially proposed fix was in some ways a hack, because it made assumptions that are in fact not met in common and important situations.

This solution takes a different route. In essence, it considers the current behavior of `jsdoc/path.getResourcePath()` broken, because it did not differentiate between filepath specifications given relative to where packages are installed, and those relative to the current or module directory (i.e., starting with `./` or `../`). This is in sharp contrast to how module identifiers are resolved by `require()`, resulting in behavior for loading plugins and templates that differed from that of loading modules, even though 3rd party plugins and templates would be installed as modules.

One solution to this would obviously be to use `require()` and `require().resolve()` for this. This may still well be the best solution, but given how the code is currently organized, it seems this would require significant surgery.

Instead I change the behavior of `jsdoc/path.getResourcePath()` here in the following ways, guided by making it _more_ consistent with what `require()` would do, so there are fewer surprises:

1. Distinguish between file paths relative to the module or working directory, and those relative to where installed packages are found. (Absolute paths left as is, as previously.)
2. If relative to module or working directory, look first there, then in the directory of the config file (this previously came first - I can hardly think of a reason why that would be logical), and only then as a fallback in the directory where JSDoc is installed.
3. If not starting with `./` or `../`, treat as relative to where installed packages are found. Look first under `node_modules/` in the current module/package and JSDoc configuration file directories, and then in the directory where JSDoc is installed.
4. For file paths starting with `node_modules/` due to legacy instructions from 3rd party plugin and template authors, prefix with `./` and then treat as relative to module/working directory (2.).

I also added tests that would pin this behavior down for the future. All previously existing tests pass, despite the changes in resolution behavior; this could obviously be because of gaps in test coverage, but it also suggests that nothing truly relied on the brokenness of the previous behavior.

Fixes #1081.

[comment]: https://github.com/jsdoc3/jsdoc/commit/6be9dac616549ce226e4c0064876c7cb3b64fe25#commitcomment-18544292