### PR TITLE
Apply @instance and @name to 'get' when defined in Object.defineProperty

### DIFF
--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -409,6 +409,43 @@ Visitor.prototype.visitNodeComments = function(node, parser, filename) {
 
     var BLOCK_COMMENT = 'Block';
 
+    // Ensure 'get' method in 'Object.defineProperty' is correctly documented
+    // 'Object.defineProperty' is an ExpressionStatement
+    if (node.type === Syntax.ExpressionStatement &&
+        node.expression.callee &&
+        node.expression.callee.type === Syntax.MemberExpression &&
+        node.expression.callee.object.name === 'Object' &&
+        node.expression.callee.property.name === 'defineProperty' &&
+        node.expression.arguments[2].properties) {
+        // node.expression.arguments[2] is the definition object passed to 'defineProperty'
+        node.expression.arguments[2].properties.forEach(function (propertyNode) {
+            if (propertyNode.key.name !== 'get') {
+                return;
+            }
+
+            var commentNode;
+            var propertyName = node.expression.arguments[1].value;
+            var newComments = '*\n* @name ' + propertyName +
+                '\n* @instance\n';
+
+            // If there are no comments at all no documentation will be generated, so
+            // inject a comment node if necessary
+            if (!propertyNode.leadingComments) {
+                propertyNode.leadingComments = [{
+                    loc: propertyNode.loc,
+                    range: propertyNode.range,
+                    type: 'Block',
+                    raw: '',
+                    value: ''
+                }];
+            }
+
+            commentNode = propertyNode.leadingComments[0];
+            commentNode.value = newComments + commentNode.value;
+            commentNode.raw = '/*' + commentNode.value + '\r\n*/';
+        });
+    }
+
     if ( !hasJsdocComments(node) && (!node.type || node.type !== BLOCK_COMMENT) ) {
         return true;
     }

--- a/test/fixtures/definePropertyGet.js
+++ b/test/fixtures/definePropertyGet.js
@@ -1,0 +1,9 @@
+/** @class */
+function Foo() {}
+
+/** Define the 'bar' property getter  */
+Object.defineProperty(Foo.prototype, 'bar', {
+    get: function() {
+        return this._bar;
+    }
+});

--- a/test/specs/documentation/definePropertyGet.js
+++ b/test/specs/documentation/definePropertyGet.js
@@ -1,0 +1,12 @@
+'use strict';
+
+describe('When a getter is defined in Object.defineProperty', function() {
+    var docSet = jasmine.getDocSetFromFile('test/fixtures/definePropertyGet.js');
+    var bar = docSet.getByLongname('bar')[0];
+
+    it('should be an instance member', function() {
+        expect(bar).toBeDefined();
+        expect(bar.kind).toBe('member');
+        expect(bar.scope).toBe('instance');
+    });
+});


### PR DESCRIPTION
This PR adds support for the `get` method when defined within a call to `Object.defineProperty`.

The functionality has been implemented with JSDoc comment injection to ensure that get methods with no JSDoc comment at all are included. Normally such a method would not appear at all in the generated documentation. With a `@type` comment, the method would be documented, but incorrectly - `@instance` and `@name` tags are also required for correct documentation. With these changes, `@instance` and `@name` can be omitted and the documentation will still be correct.