### PR TITLE
commentsOnly bug with string "path/to/**/*.js"

### DIFF
--- a/plugins/commentsOnly.js
+++ b/plugins/commentsOnly.js
@@ -10,7 +10,8 @@
 exports.handlers = {
     beforeParse: function(e) {
         // a JSDoc comment looks like: /**[one or more chars]*/
-        var comments = e.source.match(/\/\*\*[\s\S]+?\*\//g);
+        //                             and starts in new line
+        var comments = e.source.match(/\n(\s|\t)*\/\*\*[\s\S]+?\*\//g);
         if (comments) {
             e.source = comments.join('\n\n');
         } else {


### PR DESCRIPTION
I propose to make an amendment to a regular expression
`var comments = e.source.match(/\n(\s|\t)*\/\*\*[\s\S]+?\*\//g);`
that will avoid problems with a hit in a string, like `"path/to/**/*.js"`