### PR TITLE
feat: add support for a JavaScript config

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -87,8 +87,20 @@ cli.loadConfig = function() {
     }
 
     try {
-        env.conf = new Config( stripJsonComments(fs.readFileSync(confPath, 'utf8')) )
-            .get();
+        var config;
+
+        switch (path.extname(confPath)) {
+            case '.js':
+                config = require(confPath) || {};
+                break;
+            case '.json':
+            case '.EXAMPLE':
+                config = stripJsonComments(fs.readFileSync(confPath, 'utf8'));
+                break;
+            default:
+                throw new Error('Cannot use config file ' + confPath + '. Only js and json files are supported!');
+        }
+        env.conf = new Config(config).get();
     }
     catch (e) {
         cli.exit(1, 'Cannot parse the config file ' + confPath + ': ' + e + '\n' +

--- a/lib/jsdoc/config.js
+++ b/lib/jsdoc/config.js
@@ -45,11 +45,22 @@ var defaults = {
 /**
     @class
     @classdesc Represents a JSDoc application configuration.
-    @param {string} [json] - The contents of config.json.
+    @param {string|object} [jsonOrObject] - The contents of config.json, or a module exports from a js config
  */
-function Config(json) {
-    json = JSON.parse( (json || '{}') );
-    this._config = mergeRecurse(defaults, json);
+function Config(jsonOrObject) {
+    if (typeof jsonOrObject === 'undefined') {
+        jsonOrObject = {};
+    }
+
+    if (typeof jsonOrObject === 'string') {
+        jsonOrObject = JSON.parse( (jsonOrObject || '{}') );
+    }
+
+    if (typeof jsonOrObject !== 'object') {
+        jsonOrObject = {};
+    }
+
+    this._config = mergeRecurse(defaults, jsonOrObject);
 }
 
 module.exports = Config;

--- a/test/specs/jsdoc/config.js
+++ b/test/specs/jsdoc/config.js
@@ -34,6 +34,13 @@ describe('jsdoc/config', function() {
             expect( Array.isArray(config.plugins) ).toBe(true);
             expect(config.plugins.length).toBe(0);
         });
+
+        it('should be possible to construct a Config with an empty JavaScript object', function() {
+            var config = new Config({}).get();
+
+            expect( Array.isArray(config.plugins) ).toBe(true);
+            expect(config.plugins.length).toBe(0);
+        });
     });
 
     describe('constructor with plugins value', function() {
@@ -44,11 +51,25 @@ describe('jsdoc/config', function() {
             expect(config.plugins.length).toBe(1);
             expect(config.plugins[0]).toBe(42);
         });
+
+        it('should be possible to construct a Config with JavaScript object that has a plugin value', function() {
+            var config = new Config({'plugins': [42]}).get();
+
+            expect( Array.isArray(config.plugins) ).toBe(true);
+            expect(config.plugins.length).toBe(1);
+            expect(config.plugins[0]).toBe(42);
+        });
     });
 
     describe('constructor with source value', function() {
         it('should be possible to construct a Config with JSON of an object literal that has a source value', function() {
             var config = new Config('{"source":{"includePattern":"hello"}}').get();
+
+            expect(config.source.includePattern).toBe('hello');
+        });
+
+        it('should be possible to construct a Config with JavaScript object that has a source value', function() {
+            var config = new Config({'source': {'includePattern': 'hello'}}).get();
 
             expect(config.source.includePattern).toBe('hello');
         });

--- a/test/specs/jsdoc/opts/args.js
+++ b/test/specs/jsdoc/opts/args.js
@@ -39,18 +39,32 @@ describe('jsdoc/opts/args', function() {
             expect(r.template).toBe('mytemplate');
         });
 
-        it('should accept a "-c" option and return an object with a "configure" property', function() {
+        it('should accept a "-c" option with a json file and return an object with a "configure" property', function() {
             args.parse(['-c', 'myconf.json']);
             var r = args.get();
 
             expect(r.configure).toBe('myconf.json');
         });
 
-        it('should accept a "--configure" option and return an object with a "configure" property', function() {
+        it('should accept a "--configure" option with a json file and return an object with a "configure" property', function() {
             args.parse(['--configure', 'myconf.json']);
             var r = args.get();
 
             expect(r.configure).toBe('myconf.json');
+        });
+
+        it('should accept a "-c" option with a js file and return an object with a "configure" property', function() {
+            args.parse(['-c', 'myconf.js']);
+            var r = args.get();
+
+            expect(r.configure).toBe('myconf.js');
+        });
+
+        it('should accept a "--configure" option with a js file and return an object with a "configure" property', function() {
+            args.parse(['--configure', 'myconf.js']);
+            var r = args.get();
+
+            expect(r.configure).toBe('myconf.js');
         });
 
         it('should accept an "-e" option and return an object with a "encoding" property', function() {


### PR DESCRIPTION
### Changes
* Add support for a javascript config rather than a json config
* Add tests to verify that support

### Why?
Right now the only way to configure some of jsdoc is via the config file, which is fine until you want more dynamic configuration. In my case I am working on a generic build system that will be used across ~30+ projects in the future. I don't want any of them to have to worry about configuration. 

Currently I would have to write a temporary json config and clean it up right after build, in order to get dynamic template configuration properties. With this change I can easily make the javascript do that for me before I `module.exports` the config.

EX: 
```js 
var pkg = require('./package.json');

module.exports = {templates: {name: pkg.name}};
```
