### PR TITLE
Added css fix for wide images.

### DIFF
--- a/templates/default/static/styles/jsdoc-default.css
+++ b/templates/default/static/styles/jsdoc-default.css
@@ -78,6 +78,10 @@ article dl {
     margin-bottom: 40px;
 }
 
+article img {
+  max-width: 100%;
+}
+
 section
 {
     display: block;


### PR DESCRIPTION
There is small bug in default style, wide images can screw up the layout.
![broken layout](http://i.imgur.com/Jx16HPO.png)

`max-width: 100%;` solved the problem : )
![fixed layout](http://i.imgur.com/gP0ZfuM.png)