### PR TITLE
Add line number and column to parse error message

### DIFF
--- a/lib/jsdoc/src/astbuilder.js
+++ b/lib/jsdoc/src/astbuilder.js
@@ -160,7 +160,7 @@ function parse(source, filename) {
         ast = espree.parse(source, parserOptions);
     }
     catch (e) {
-        jsdoc.util.logger.error('Unable to parse %s: %s', filename, e.message);
+        jsdoc.util.logger.error('Unable to parse %s:%s:%s: %s', filename, e.lineNumber, e.column, e.message);
     }
 
     return ast;


### PR DESCRIPTION
This PR makes the error message from espree.parse more detailed, including line number and column in source. Fixes #1345.

Makes it easier for users to correct unparseable files.