### PR TITLE
Deferred process.exit() to allow STDOUT pipe to flush

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -466,7 +466,7 @@ cli.exit = function(exitCode, message) {
     if (exitCode > 0 && message) {
         console.error(message);
     }
-    process.exit(exitCode);
+    process.on('exit', function() { process.exit(exitCode); });
 };
 
 return cli;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | n/a
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->
Since process.exit() is an imperative that exits immediately, pending
contents written to STDOUT is lost, if STDOUT is connected to a pipe
(as it is, for example, when used by sphinx-js to generate automatic
class descriptions).

The deferred exit in this commit allows STDOUT to flush its full
contents, before the jsdoc process exits with the designated exit code.

Please see
https://github.com/nodejs/node-v0.x-archive/issues/3737#issuecomment-19156072
for details.