### PR TITLE
Removed no dictionary error log.

### DIFF
--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -1076,14 +1076,13 @@ exports.defineTags = function(dictionary, tagDefinitions) {
         dictionaries.forEach(function(dictName) {
             var tagDefs = exports[DEFINITIONS[dictName]];
 
-            if (!tagDefs) {
-                jsdoc.util.logger.error('The configuration setting "tags.dictionaries" contains ' +
-                    'the unknown dictionary name %s. Ignoring the dictionary.', dictName);
-
-                return;
+            if (tagDefs) {
+                addTagDefinitions(dictionary, _.extend(tagDefs, internalTags));
             }
-
-            addTagDefinitions(dictionary, _.extend(tagDefs, internalTags));
+            else{
+                addTagDefinitions(dictionary, internalTags);
+            }
+            
         });
     }
     else {


### PR DESCRIPTION
User may define his own dictionary as a plugin instead of using the build one.