### PR TITLE
Prefer copyFileSync from here over native

### DIFF
--- a/lib/jsdoc/fs.js
+++ b/lib/jsdoc/fs.js
@@ -120,6 +120,13 @@ exports.copyFileSync = function(inFile, outDir, fileName) {
     return fs.closeSync(write);
 };
 
+var alwaysOverride = {
+    'copyFileSync': true
+};
+
 Object.keys(fs).forEach(function(member) {
-    exports[member] = fs[member];
+    if (!alwaysOverride[member]) {
+        exports[member] = fs[member];
+    }
 });
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/jsdoc3/jsdoc"
   },
   "dependencies": {
-    "babylon": "~7.0.0-beta.19",
+    "babylon": "7.0.0-beta.19",
     "bluebird": "~3.5.0",
     "catharsis": "~0.8.9",
     "escape-string-regexp": "~1.0.5",


### PR DESCRIPTION
`lib/jsdoc/fs.js` always prefers native implementations over its overrides. With node v8.5 implementing `copyFile` and `copyFileSync` natively with a different API, building docs broke.

I've made it so overrides can now easily be preferred by adding them to the `alwaysOverride` object.

Fixes #1438.
