### PR TITLE
Add ability to pass options and plugins to MarkdownIt instance

### DIFF
--- a/lib/jsdoc/util/markdown.js
+++ b/lib/jsdoc/util/markdown.js
@@ -4,6 +4,7 @@
  */
 'use strict';
 
+var _ = require('underscore');
 var env = require('jsdoc/env');
 var logger = require('jsdoc/util/logger');
 var MarkdownIt = require('markdown-it');
@@ -238,14 +239,24 @@ function getParseFunction(parserName, conf) {
             return parserFunction;
 
         case parserNames.markdownit:
-            renderer = new MarkdownIt({
+            renderer = new MarkdownIt(_.extend({
                 breaks: Boolean(conf.hardwrap),
                 highlight: highlighter,
                 html: true
-            });
+            }, conf.parserOptions));
 
             if (conf.idInHeadings) {
                 renderer.use(mdnh);
+            }
+
+            if (conf.parserPlugins) {
+                conf.parserPlugins.forEach(function(plugin) {
+                    if (Array.isArray(plugin)) {
+                        renderer.use.apply(renderer, plugin);
+                    } else {
+                        renderer.use(plugin);
+                    }
+                });
             }
 
             parserFunction = function(source) {

--- a/test/fixtures/markdown/plugins/changeCase.js
+++ b/test/fixtures/markdown/plugins/changeCase.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var UNESCAPE_RE = /\\([ \\!"#$%&'()*+,.\/:;<=>?@[\]^_`{|}~-])/g;
+var CARET = 0x5E;
+
+
+module.exports = function changeCasePlugin(md, transform) {
+    md.inline.ruler.after('emphasis', 'change_case', function(state) {
+        var max = state.posMax;
+        var start = state.pos;
+
+        if (state.src.charCodeAt(start) !== CARET || start + 2 >= max) {
+            return false;
+        }
+
+        state.pos = start + 1;
+
+        var found;
+        while (state.pos < max) {
+            if (state.src.charCodeAt(state.pos) === CARET) {
+                found = true;
+                break;
+            }
+
+            state.md.inline.skipToken(state);
+        }
+
+        if (!found || start + 1 === state.pos) {
+            state.pos = start;
+            return false;
+        }
+
+        var content = state.src.slice(start + 1, state.pos);
+
+        state.posMax = state.pos;
+        state.pos = start + 1;
+
+        var token = state.push('text', '', 0);
+        token.markup = '^';
+        token = state.push('text', '', 0);
+        token.content = content.replace(UNESCAPE_RE, '$1');
+        token.content = transform === 'lower' ? token.content.toLowerCase() : token.content.toUpperCase();
+        token = state.push('text', '', 0);
+        token.markup = '^';
+
+        state.pos = state.posMax + 1;
+        state.posMax = max;
+        return true;
+    });
+};

--- a/test/specs/jsdoc/util/markdown.js
+++ b/test/specs/jsdoc/util/markdown.js
@@ -4,6 +4,7 @@ describe('jsdoc/util/markdown', function() {
     var env = require('jsdoc/env');
     var logger = require('jsdoc/util/logger');
     var markdown = require('jsdoc/util/markdown');
+    var changeCasePlugin = require('../../../fixtures/markdown/plugins/changeCase');
 
     it('should exist', function() {
         expect(markdown).toBeDefined();
@@ -121,6 +122,33 @@ describe('jsdoc/util/markdown', function() {
             parser = markdown.getParser();
 
             expect(parser('# Hello')).toBe('<h1 id="hello">Hello</h1>');
+        });
+
+        it('should apply parserOptions to the MarkdownIt plugin', function() {
+            var parser;
+
+            setMarkdownConf({parserOptions: {linkify: true}});
+            parser = markdown.getParser();
+
+            expect(parser('Hello https://www.google.com/')).toBe('<p>Hello <a href="https://www.google.com/">https://www.google.com/</a></p>');
+        });
+
+        it('should apply parserPlugins to the MarkdownIt plugin', function() {
+            var parser;
+
+            setMarkdownConf({parserPlugins: [changeCasePlugin]});
+            parser = markdown.getParser();
+
+            expect(parser('Hello ^World^')).toBe('<p>Hello WORLD</p>');
+        });
+
+        it('should apply arguments to parserPlugins to the MarkdownIt plugin', function() {
+            var parser;
+
+            setMarkdownConf({parserPlugins: [[changeCasePlugin, 'lower']]});
+            parser = markdown.getParser();
+
+            expect(parser('Hello ^World^')).toBe('<p>Hello world</p>');
         });
 
         it('should not pretty-print code blocks that start with "```plain"', function() {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| Fixed issues     | 
| License          | Apache-2.0

Added the ability to pass options into MarkdownIt. MarkdownIt is a powerful tool and having the option to provide additional options and plugins (e.g. enabling automatic hyperlink generation from URLs, adding plugins that extend syntax, and so on) is definitely a nice-to-have, but the MarkdownIt instance used by jsdoc is not exposed.

This adds options:

| Option | Type | Description |
| :--- | :--- | :--- |
| `conf.markdown.parserOptions` | object | Options to pass to the MarkdownIt constructor. |
| `conf.markdown.parserPlugins` | array&lt;function&gt; \| array&lt;array&lt;function&gt;&gt; | An array of parser plugins. If the plugin requires options to pass to it, then the item may be a nested array, where the first element is the plugin function and the following elements are parameters to pass into the function. |

### Example

```js
module.exports = {
  plugins: ['plugins/markdown'],
  parserOptions: {
    linkify: true,
  },
  parserPlugins: [
    require('markdown-it-sub'),
    [require('markdown-it-emoji'), { enabled: ['smile'] }],
  ],
}
```