### PR TITLE
added support for .mjs files, fixes #1430

### DIFF
--- a/conf.json.EXAMPLE
+++ b/conf.json.EXAMPLE
@@ -3,7 +3,7 @@
         "allowUnknownTags": true
     },
     "source": {
-        "includePattern": ".+\\.js(doc|x)?$",
+        "includePattern": ".+\\.(js(doc|x)?|mjs)$",
         "excludePattern": "(^|\\/|\\\\)_"
     },
     "plugins": [],

--- a/lib/jsdoc/config.js
+++ b/lib/jsdoc/config.js
@@ -27,7 +27,7 @@ var defaults = {
     plugins: [],
     recurseDepth: 10,
     source: {
-        includePattern: '.+\\.js(doc|x)?$',
+        includePattern: '.+\\.(js(doc|x)?|mjs)$',
         excludePattern: ''
     },
     sourceType: 'module',

--- a/test/specs/jsdoc/src/filter.js
+++ b/test/specs/jsdoc/src/filter.js
@@ -18,7 +18,7 @@ describe('jsdoc/src/filter', function() {
     describe('Filter', function() {
         var myFilter;
 
-        var defaultIncludePattern = new RegExp('.+\\.js(doc)?$');
+        var defaultIncludePattern = new RegExp('.+\\.(js(doc|x)?|mjs)$');
         var defaultExcludePattern = new RegExp('(^|\\/|\\\\)_');
 
         beforeEach(function() {
@@ -102,6 +102,7 @@ describe('jsdoc/src/filter', function() {
             it('should return the correct source files', function() {
                 var files = [
                     'yes.js',
+                    'yes.mjs',
                     '/yes.jsdoc',
                     '/_nope.js',
                     '.ignore',
@@ -118,8 +119,9 @@ describe('jsdoc/src/filter', function() {
                     return myFilter.isIncluded($);
                 });
 
-                expect(files.length).toEqual(2);
+                expect(files.length).toEqual(3);
                 expect( files.indexOf('yes.js') ).toBeGreaterThan(-1);
+                expect( files.indexOf('yes.mjs') ).toBeGreaterThan(-1);
                 expect( files.indexOf('/yes.jsdoc') ).toBeGreaterThan(-1);
             });
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| Fixed issues     | #1430
| License          | Apache-2.0

This PR adds support to scanning `*.mjs` file names by modifying the default Filter's `includePattern` regexp.