### PR TITLE
fix overriding of the class documentation when it's constructor doesn…

### DIFF
--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -333,6 +333,17 @@ function makeConstructorFinisher(parser) {
 
         combined = jsdoc.doclet.combine(doclet, parentDoclet);
         combined.longname = parentDoclet.longname;
+
+        // make sure an undocumented constructor won't override a documented class
+        // remove the 'undocumented = true' property when the parentDoclet didn't had it.
+        if (combined.undocumented === true && !parentDoclet.undocumented) {
+            delete combined.undocumented;
+        }
+        // add the parentDoclet's comment back if only the constructor didn't had any comments.
+        if (combined.comment === '' && parentDoclet.comment !== '') {
+            combined.comment = parentDoclet.comment;
+        }
+
         if (parentDoclet.memberof) {
             combined.memberof = parentDoclet.memberof;
         }


### PR DESCRIPTION
fix overriding of the class documentation when it's constructor doesn't have a documentation (#1456)

<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | #1456 
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->
When a class has a constructor, the comment of the class declaration and the constructor are merged (combined) together, where the constructor's Doclet has precedence. In case the class has a documentation (comment block) but the constructor does not, then the doclets properties `undocumented=true` and `comment=""` would override the values from the class which resulted to the whole class having the `undocumented` flag.
In commit 12094ba , this exact scenario is tested, and the `undocumented` flag removed and the comment blog added back to the doclet.

I didn't add any testes, i think the `visitNode` test in `\test\specs\jsdoc\src\visitor.js` would be the correct position to add tests to for this fix. But `visitNode` test is already deactiveted. so..