### PR TITLE
@ignore is ignored on enum properties

### DIFF
--- a/lib/jsdoc/schema.js
+++ b/lib/jsdoc/schema.js
@@ -119,6 +119,9 @@ var ENUM_PROPERTY_SCHEMA = exports.ENUM_PROPERTY_SCHEMA = {
         description: {
             type: STRING_OPTIONAL
         },
+        ignore: {
+            type: BOOLEAN
+        },
         kind: {
             type: STRING,
             enum: ['member']

--- a/lib/jsdoc/src/parser.js
+++ b/lib/jsdoc/src/parser.js
@@ -667,7 +667,9 @@ Parser.prototype.resolveEnum = function(e) {
             e.doclet.defaultvalue = e.doclet.meta.code.value;
 
             // add the doclet to the parent's properties
-            doclet.properties.push(e.doclet);
+            if (!e.doclet.ignore) {
+                doclet.properties.push(e.doclet);
+            }
         }
     });
 };

--- a/test/fixtures/enumtag.js
+++ b/test/fixtures/enumtag.js
@@ -19,3 +19,18 @@ var TrueFalseNumeric = {
     0: false,
     1: true
 };
+
+/**
+ * Enum with ignored entries.
+ * @enum
+ */
+var SomeIgnored = {
+    /** One */
+    one: 1,
+    /** Two
+     * @ignore */
+    two: 2,
+    three: 3,
+    /** @ignore */
+    four: 4
+};

--- a/test/specs/tags/enumtag.js
+++ b/test/specs/tags/enumtag.js
@@ -17,6 +17,16 @@ describe('@enum tag', function() {
         expect(tristate.properties[1].undocumented).toBeUndefined();
     });
 
+    it('If @ignore is set on the property, it is omitted from the enum.', function() {
+        var someignored = docSet.getByLongname('SomeIgnored')[0];
+        var propertyNames = someignored.properties.map(function(p) { return p.name; });
+        expect(propertyNames.length).toBe(2);
+        expect(propertyNames).toContain('one');
+        expect(propertyNames).not.toContain('two');
+        expect(propertyNames).toContain('three');
+        expect(propertyNames).not.toContain('four');
+    });
+
     it('A property of an enum gets its defaultvalue set.', function() {
         expect(tristate.properties[1].defaultvalue).toBe(-1);
     });


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| Fixed issues     |
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->

I have an `@enum` of whose properties I only want some documented, so I marked the others with `@ignore`. That did not help however, they were still included in the output.

*Input:*
```JavaScript
/**
 * Enum with ignored entries.
 * @enum
 */
var SomeIgnored = {
    /** One */
    one: 1,
    /** @ignore */
    two: 2,
    three: 3
};
```

*Expected result:* Documentation mentioning `one` and `three`, but not `two`.
*Actual result:* All three values documented.

The attached commit, with test, appears to fix this.