### PR TITLE
Support Closure Compiler path types

### DIFF
--- a/lib/jsdoc/opts/args.js
+++ b/lib/jsdoc/opts/args.js
@@ -38,6 +38,7 @@ argParser.addOption('u', 'tutorials',   true,  'Directory in which JSDoc should 
 argParser.addOption('v', 'version',     false, 'Display the version number and quit.');
 argParser.addOption('',  'verbose',     false, 'Log detailed information to the console as JSDoc runs.');
 argParser.addOption('X', 'explain',     false, 'Dump all found doclet internals to console and quit.');
+argParser.addOption('m', 'moduleRoot',  true,  'Root of the used @module paths. When provided, Closure Compiler path types will be resolved.');
 /* eslint-enable no-multi-spaces */
 
 // Options that are no longer supported and should be ignored

--- a/lib/jsdoc/tag.js
+++ b/lib/jsdoc/tag.js
@@ -69,7 +69,15 @@ function addHiddenProperty(obj, propName, propValue) {
 
 function parseType(tag, tagDef, meta) {
     try {
-        return jsdoc.tag.type.parse(tag.text, tagDef.canHaveName, tagDef.canHaveType);
+        var modulePath;
+        var moduleRoot = jsdoc.env.opts.moduleRoot;
+
+        if (moduleRoot) {
+            modulePath = path.relative(path.resolve(jsdoc.env.pwd, moduleRoot), meta.path);
+            modulePath = modulePath.replace(new RegExp('\\' + path.sep, 'g'), '/');
+        }
+
+        return jsdoc.tag.type.parse(tag.text, tagDef.canHaveName, tagDef.canHaveType, modulePath);
     }
     catch (e) {
         jsdoc.util.logger.error(

--- a/lib/jsdoc/tag/type.js
+++ b/lib/jsdoc/tag/type.js
@@ -236,9 +236,11 @@ function getTypeStrings(parsedType, isOutermostType) {
  *
  * @private
  * @param {module:jsdoc/tag/type.TagInfo} tagInfo - Information contained in the tag.
+ * @param {string} [modulePath] Optional module path for Closure Compiler path type resolution.
+ * For `@module foo/bar`, the `modulePath` would be `foo`.
  * @return {module:jsdoc/tag/type.TagInfo} Updated information from the tag.
  */
-function parseTypeExpression(tagInfo) {
+function parseTypeExpression(tagInfo, modulePath) {
     var parsedType;
 
     // don't try to parse empty type expressions
@@ -247,7 +249,10 @@ function parseTypeExpression(tagInfo) {
     }
 
     try {
-        parsedType = catharsis.parse(tagInfo.typeExpression, {jsdoc: true});
+        parsedType = catharsis.parse(tagInfo.typeExpression, {
+            jsdoc: true,
+            modulePath: modulePath
+        });
     }
     catch (e) {
         // always re-throw so the caller has a chance to report which file was bad
@@ -284,10 +289,12 @@ var typeParsers = [parseName, parseTypeExpression];
  * @param {boolean} canHaveName - Indicates whether the value can include a symbol name.
  * @param {boolean} canHaveType - Indicates whether the value can include a type expression that
  * describes the symbol.
+ * @param {string} [modulePath] - Optional module path for Closure Compiler path type resolution.
+ * For `@module foo/bar`, the `modulePath` would be `foo`.
  * @return {module:jsdoc/tag/type.TagInfo} Information obtained from the tag.
  * @throws {Error} Thrown if a type expression cannot be parsed.
  */
-exports.parse = function(tagValue, canHaveName, canHaveType) {
+exports.parse = function(tagValue, canHaveName, canHaveType, modulePath) {
     var tagInfo;
 
     if (typeof tagValue !== 'string') {
@@ -298,7 +305,7 @@ exports.parse = function(tagValue, canHaveName, canHaveType) {
     tagInfo.type = tagInfo.type || [];
 
     typeParsers.forEach(function(parser) {
-        tagInfo = parser(tagInfo);
+        tagInfo = parser(tagInfo, modulePath);
     });
 
     // if we wanted a type, but the parsers didn't add any type names, use the type expression

--- a/test/specs/jsdoc/tag.js
+++ b/test/specs/jsdoc/tag.js
@@ -10,6 +10,7 @@ describe('jsdoc/tag', function() {
         type: require('jsdoc/tag/type')
     };
     var logger = require('jsdoc/util/logger');
+    var path = require('jsdoc/path');
 
     it('should exist', function() {
         expect(jsdoc.tag).toBeDefined();
@@ -240,6 +241,16 @@ describe('jsdoc/tag', function() {
                 /* eslint-enable no-unused-vars */
 
                 expect(logger.error).toHaveBeenCalled();
+            });
+        });
+
+        describe('parseType', function() {
+            it('resolves path types to module types when moduleRoot is set', function() {
+                jsdoc.env.opts.moduleRoot = './';
+                var tag = new jsdoc.tag.Tag('type', '{./bar.mytype}', {path: path.resolve(jsdoc.env.pwd, 'foo')});
+
+                delete jsdoc.env.opts.moduleRoot;
+                expect(tag.value.type.names[0]).toBe('module:foo/bar.mytype');
             });
         });
     });


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| License          | Apache-2.0

This pull request adds a `--moduleRoot` (`-m`) config option to JSDoc. When provided, Closure Compiler [path types](https://github.com/google/closure-compiler/wiki/JS-Modules#type-references) are resolved to JSDoc `module:` types:

`src/foo/Bar.js`
```js
/** @module foo/Bar */

/**
 * @type {../types.Coordinate}
 */
var coordinate = [16, 48];
```
`src/types.js`
```js
/** @module types */

/**
 * 2D coordinate (longitude, latitude).
 * @typedef {Array<number>}
 */
export var Coordinate;
```

    jsdoc --modulePath src/ -r src/

will create documentation with a working link from `src/foo/Bar.js`'s `coordinate` documentation as `module:types.Coordinate` type.

**Note:** Tests will fail until the pull request is updated to use a version of Catharsis with hegemonic/catharsis#52 merged. 