### PR TITLE
Update marked version for security reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "klaw": "~2.0.0",
     "markdown-it": "~8.3.1",
     "markdown-it-named-headers": "~0.0.4",
-    "marked": "~0.3.6",
+    "marked": "~0.3.9",
     "mkdirp": "~0.5.1",
     "requizzle": "~0.2.1",
     "strip-json-comments": "~2.0.1",


### PR DESCRIPTION
The version is set to "~0.3.9"

Fixes #1489

| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | 1489
| License          | Apache-2.0

This change is to avoid using 0.3.6 of marked which was labeled as having security vulnerabilities.