### PR TITLE
update marked to v0.3.9+

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "klaw": "~2.0.0",
     "markdown-it": "~8.3.1",
     "markdown-it-named-headers": "~0.0.4",
-    "marked": "~0.3.6",
+    "marked": "~0.3.9",
     "mkdirp": "~0.5.1",
     "requizzle": "~0.2.1",
     "strip-json-comments": "~2.0.1",


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | (security)
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->

JSDoc relies on the Marked package, currently locked to v0.3.6.  This version specifically suffers from 2 security vulnerabilities https://nvd.nist.gov/vuln/detail/CVE-2017-17461 and https://nvd.nist.gov/vuln/detail/CVE-2017-1000427.  

This PR updates Marked to v0.3.9, the closet version which closes these vulnerabilities.  No other packages are updated.
