### PR TITLE
output full path to file when errors occur during validation

### DIFF
--- a/lib/jsdoc/tag/validator.js
+++ b/lib/jsdoc/tag/validator.js
@@ -7,9 +7,10 @@
 var env = require('jsdoc/env');
 var format = require('util').format;
 var logger = require('jsdoc/util/logger');
+var path = require('path');
 
 function buildMessage(tagName, meta, desc) {
-    var result = format('The @%s tag %s. File: %s, line: %s', tagName, desc, meta.filename,
+    var result = format('The @%s tag %s. File: %s, line: %s', tagName, desc, path.join(meta.path, meta.filename),
         meta.lineno);
 
     if (meta.comment) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | 
| License          | Apache-2.0

output full path to file when errors occur during validation

for example, if a project has several index.js files with errors, previously, the jsdoc output would have ambiguous index.js errors with line numbers since only the file name without its path was listed
