### PR TITLE
Support `exports` as a namespace name

### DIFF
--- a/lib/jsdoc/src/handlers.js
+++ b/lib/jsdoc/src/handlers.js
@@ -250,9 +250,11 @@ function addSymbolMemberof(parser, doclet, astNode) {
     // TODO: handle cases where the module object is shadowed in the current scope
     if (currentModule) {
         moduleOriginalName = '|' + currentModule.originalName;
+        resolveTargetRegExp = new RegExp('^((?:module.)?exports|this' +
+            moduleOriginalName + ')(\\.|\\[|$)');
+    } else {
+        resolveTargetRegExp = new RegExp('^(this)(\\.|\\[|$)');
     }
-    resolveTargetRegExp = new RegExp('^((?:module.)?exports|this' + moduleOriginalName +
-        ')(\\.|\\[|$)');
     unresolved = resolveTargetRegExp.exec(doclet.name);
 
     if (unresolved) {

--- a/test/fixtures/mixintag.js
+++ b/test/fixtures/mixintag.js
@@ -24,3 +24,6 @@ var FormButton = function() {
  * @constructor MyClass
  * @mixes Eventful
  * @mixes AnotherMixin */
+
+/** @mixin exports */
+exports.aMethod = function() {};

--- a/test/fixtures/namespacetag.js
+++ b/test/fixtures/namespacetag.js
@@ -9,3 +9,6 @@ var S = {
 	/** Member of the namespace S. */
 	Socket: function() {}
 };
+
+/** @namespace exports */
+exports.version = '1.0.0';

--- a/test/specs/tags/mixintag.js
+++ b/test/specs/tags/mixintag.js
@@ -4,12 +4,20 @@ describe('@mixin tag', function() {
     var docSet = jasmine.getDocSetFromFile('test/fixtures/mixintag.js');
     var Eventful = docSet.getByLongname('Eventful')[0];
     var Mixin = docSet.getByLongname('AnotherMixin')[0];
+    var exportsMixin = docSet.getByLongname('exports')[0];
+    var aMethod = docSet.getByLongname('exports.aMethod')[0];
 
     it("When a symbol has a @mixin tag, the doclet's 'kind' property is set to 'mixin'", function() {
         expect(Eventful.kind).toBe('mixin');
+        expect(exportsMixin.kind).toBe('mixin');
     });
 
     it("When a symbol has a @mixin tag, its name is set to the tag's value (if present)", function() {
         expect(Mixin).toBeDefined();
+    });
+
+    it("When a symbol named 'export' is a @mixin, its members are available", function() {
+        expect(aMethod).toBeDefined();
+        expect(aMethod.name).toBe('aMethod');
     });
 });

--- a/test/specs/tags/namespacetag.js
+++ b/test/specs/tags/namespacetag.js
@@ -6,17 +6,21 @@ describe('@namespace tag', function() {
     var Foo = docSet.getByLongname('Foo')[0];
     var Bar = docSet.getByLongname('Bar')[0];
     var Socket = docSet.getByLongname('S.Socket')[0];
+    var exportsNs = docSet.getByLongname('exports')[0];
+    var version = docSet.getByLongname('exports.version')[0];
 
     it("sets the doclet's kind to 'namespace'", function() {
         expect(x.kind).toBe('namespace');
         expect(Foo.kind).toBe('namespace');
         expect(Bar.kind).toBe('namespace');
+        expect(exportsNs.kind).toBe('namespace');
     });
 
     it("sets the doclet's name to the tag value (if provided)", function() {
         expect(x.name).toBe('x');
         expect(Foo.name).toBe('Foo');
         expect(Bar.name).toBe('Bar');
+        expect(exportsNs.name).toBe('exports');
     });
 
     it("sets the doclet's type (if provided in @namespace)", function() {
@@ -30,5 +34,8 @@ describe('@namespace tag', function() {
         function() {
             expect(Socket).toBeDefined();
             expect(Socket.name).toBe('Socket');
+
+            expect(version).toBeDefined();
+            expect(version.name).toBe('version');
         });
 });


### PR DESCRIPTION
Authors of CommonJS modules may wish to define the module's members as a
namespace or mixin rather than a module. Limit special treatment of the
`exports` identifier to code which has been configured as a module.

<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| Fixed issues     | 
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->
