### PR TITLE
Make maintainers an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
       "url": "https://github.com/jsdoc3/jsdoc/graphs/contributors"
     }
   ],
-  "maintainers": {
+  "maintainers": [{
     "name": "Jeff Williams",
     "email": "jeffrey.l.williams@gmail.com"
-  }
+  }]
 }


### PR DESCRIPTION
See npm/npm#11056 for examples of `npm` issues that can arise when `maintainers` is not an array.