### PR TITLE
Scroll to the selected line manually

### DIFF
--- a/templates/default/static/scripts/linenumber.js
+++ b/templates/default/static/scripts/linenumber.js
@@ -19,6 +19,7 @@
             lines[i].id = lineId;
             if (lineId === anchorHash) {
                 lines[i].className += ' selected';
+                lines[i].scrollIntoView();
             }
         }
     }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | no
| License          | Apache-2.0

`linenumber.js` creates line numbers in source codes dynamically. In some cases, `#linenumber` hash anchor does not work properly by timing issues. So I add `linenumberElement.scrollIntoView()` to scroll manually.
XRef: https://github.com/sprintseoul/history/blob/master/201902.md
