### PR TITLE
New option lowercase file names

### DIFF
--- a/lib/jsdoc/opts/args.js
+++ b/lib/jsdoc/opts/args.js
@@ -22,6 +22,7 @@ argParser.addOption('d', 'destination', true,  'The path to the output folder. D
 argParser.addOption('',  'debug',       false, 'Log information for debugging JSDoc.');
 argParser.addOption('e', 'encoding',    true,  'Assume this encoding when reading all source files. Default: utf8');
 argParser.addOption('h', 'help',        false, 'Print this message and quit.');
+argParser.addOption('',  'lowercase',   false, 'The file names and its links are converted to lowercase.');
 argParser.addOption('',  'match',       true,  'When running tests, only use specs whose names contain <value>.', true);
 argParser.addOption('',  'nocolor',     false, 'When running tests, do not use color in console output.');
 argParser.addOption('p', 'private',     false, 'Display symbols marked with the @private tag. Equivalent to "--access all". Default: false');

--- a/lib/jsdoc/util/templateHelper.js
+++ b/lib/jsdoc/util/templateHelper.js
@@ -139,6 +139,8 @@ const getUniqueFilename = exports.getUniqueFilename = str => {
 
     // in case we've now stripped the entire basename (uncommon, but possible):
     basename = basename.length ? basename : '_';
+    // if lowercase option exists
+    basename = env.opts.lowercase ? basename.toLowerCase(): basename;
 
     return makeUniqueFilename(basename, str) + exports.fileExtension;
 };


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | none
| License          | Apache-2.0

## Details
**The small change that I propose is a new option to convert the names of the generated files and its links to lowercase.**
This option is useful, for example, in the following circumstances (own experience):
We change the capitalization of a class in the local repository, i.e.:   
"npcFactory" -> "NpcFactory".
When generating the documentation, a file with the new name is created:   
"npcFactory.html" -> "NpcFactory.html".
But when we send the changes to the remote repository, git does not recognize this type of name change, so it sends the new file with the old name. In this way, in the remote repository the new links cause "404" errors.
There is a solution using "git mv", but if there are many affected files, it will waste your time.
The option that I propose would allow changing the names of our code, without affecting the capitalization of the file names and links.

## Usage
* Command line:
```
jsdoc file.js --lowercase
```
* In config file:
```json
{
    "opts": {
        "lowercase": true
    }
}
```
Regards.